### PR TITLE
OPENEUROPA-1111: Entities originating from external producers should be read only

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ your respective URI):
 $config['oe_content.settings']['provenance_uri'] = 'http://example.com';
 ```
 
-The task runner will automatically add this on your development environment.
-
 ## Requirements
 
 This depends on the following software:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ In order to determine the provenance of an entity, a "provenance URI" can be set
 at the site level, which gets automatically saved with the entity. Access rules also
 depend on this URI.
 
-To set the provenance URI, add the following line to the settings.php file (with the
+When installing the module, the provenance URI is set based on the base URL of the site.
+However, it can be overridden by adding the following line to the settings.php file (with the
 your respective URI):
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 This is a Drupal module that contains the EC corporate entity types.
 
+The main entity type is the RDF Entity which has the following bundles:
+
+* Event
+* Announcement
+
+All bundles of this entity type have predicate mappings for RDF shared storage.
+In order to determine the provenance of an entity, a "provenance URI" can be set
+at the site level, which gets automatically saved with the entity. Access rules also
+depend on this URI.
+
+To set the provenance URI, add the following line to the settings.php file (with the
+your respective URI):
+
+```
+$config['oe_content.settings']['provenance_uri'] = 'http://example.com';
+```
+
+The task runner will automatically add this on your development environment.
+
 ## Requirements
 
 This depends on the following software:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -5,7 +5,6 @@ default:
         - %paths.base%/tests/features
       contexts:
         - Drupal\DrupalExtension\Context\MinkContext
-        - Drupal\DrupalExtension\Context\ConfigContext
         - Drupal\Tests\oe_content\Behat\RdfEntityContext
         - Drupal\Tests\oe_content\Behat\FeatureContext
   extensions:

--- a/oe_content.install
+++ b/oe_content.install
@@ -24,3 +24,15 @@ function oe_content_requirements($phase) {
 
   return $requirements;
 }
+
+/**
+ * Implements hook_install().
+ */
+function oe_content_install() {
+  // @codingStandardsIgnoreLine
+  global $base_url;
+  \Drupal::configFactory()
+    ->getEditable('oe_content.settings')
+    ->set('provenance_uri', $base_url)
+    ->save();
+}

--- a/oe_content.module
+++ b/oe_content.module
@@ -5,9 +5,11 @@
  * The OpenEuropa Content module.
  */
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\rdf_entity\Entity\Rdf;
 
 /**
@@ -59,4 +61,16 @@ function oe_content_rdf_apply_default_fields_alter($type, &$values) {
       }
     }
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_access().
+ */
+function oe_content_rdf_entity_access(EntityInterface $entity, $operation, AccountInterface $account) {
+  if ($operation == 'view') {
+    return AccessResult::neutral();
+  }
+
+  $provenance_uri = \Drupal::config('oe_content.settings')->get('provenance_uri');
+  return $entity->get('provenance_uri')->value === $provenance_uri ? AccessResult::allowed() : AccessResult::forbidden();
 }

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -40,6 +40,9 @@ drupal:
           port: ${drupal.sparql.port}
           namespace: 'Drupal\rdf_entity\Database\Driver\sparql'
           driver: 'sparql'
+    config:
+      oe_content.settings:
+        provenance_uri: 'http://example.com'
 
 commands:
   drupal:site-setup:

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -40,9 +40,6 @@ drupal:
           port: ${drupal.sparql.port}
           namespace: 'Drupal\rdf_entity\Database\Driver\sparql'
           driver: 'sparql'
-    config:
-      oe_content.settings:
-        provenance_uri: 'http://example.com'
 
 commands:
   drupal:site-setup:

--- a/tests/Behat/RdfEntityContext.php
+++ b/tests/Behat/RdfEntityContext.php
@@ -6,15 +6,19 @@ namespace Drupal\Tests\oe_content\Behat;
 
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Drupal\DrupalExtension\Context\RawDrupalContext;
+use Drupal\DrupalExtension\Context\ConfigContext;
+use Drupal\rdf_entity\RdfInterface;
 
 /**
  * Defines step definitions specifically for testing the RDF entities.
  *
  * This is needed due to issues with the Kernel testing of the RDF entity module
  * in Drupal 8.6.
+ *
+ * We are extending ConfigContext to override the setConfig() method until
+ * issue https://github.com/jhedstrom/drupalextension/issues/498 is fixed.
  */
-class RdfEntityContext extends RawDrupalContext {
+class RdfEntityContext extends ConfigContext {
 
   /**
    * An array of RDF entities we need to keep track to delete.
@@ -22,26 +26,6 @@ class RdfEntityContext extends RawDrupalContext {
    * @var \Drupal\rdf_entity\RdfInterface[]
    */
   protected $rdfEntities = [];
-
-  /**
-   * The Configuration context.
-   *
-   * @var \Drupal\DrupalExtension\Context\ConfigContext
-   */
-  protected $configContext;
-
-  /**
-   * Before scenario hook get the ConfigContext.
-   *
-   * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
-   *   The Hook scope.
-   *
-   * @BeforeScenario
-   */
-  public function gatherConfigContext(BeforeScenarioScope $scope): void {
-    $environment = $scope->getEnvironment();
-    $this->configContext = $environment->getContext('Drupal\DrupalExtension\Context\ConfigContext');
-  }
 
   /**
    * After scenario hook to delete the RDF entities.
@@ -70,16 +54,17 @@ class RdfEntityContext extends RawDrupalContext {
    * @BeforeScenario @rdf-provenance
    */
   public function setDefaultProvenance(BeforeScenarioScope $scope): void {
-    $this->configContext->setConfig('oe_content.settings', 'provenance_uri', 'http://example.com');
+    $this->setConfig('oe_content.settings', 'provenance_uri', 'http://example.com');
   }
 
   /**
    * Configures the Provenance URI.
    *
    * @Given the site Provenance URI is set to :uri
+   * @And the site Provenance URI is set to :uri
    */
   public function theSiteProvenanceUriIsSetTo($uri): void {
-    $this->configContext->setConfig('oe_content.settings', 'provenance_uri', $uri);
+    $this->setConfig('oe_content.settings', 'provenance_uri', $uri);
   }
 
   /**
@@ -90,7 +75,7 @@ class RdfEntityContext extends RawDrupalContext {
    *
    * @Given I am logged in with a user that can create and view :bundle RDF entities
    */
-  public function iAmLoggedInWithUserThatCanCreateAndViewRdfEntityTypes($bundle) {
+  public function iAmLoggedInWithUserThatCanCreateAndViewRdfEntityTypes($bundle): void {
     /** @var \Drupal\rdf_entity\RdfEntityTypeInterface[] $types */
     $types = \Drupal::entityTypeManager()->getStorage('rdf_type')->loadMultiple();
     $permission_map = [];
@@ -143,14 +128,8 @@ class RdfEntityContext extends RawDrupalContext {
    * @Then the Provenance URI of the RDF entity with the name :name should be :provenance_uri
    */
   public function theProvenanceUriOfTheRdfEntityWithTheNameShouldBe($name, $provenance_uri): void {
-    $entities = \Drupal::entityTypeManager()->getStorage('rdf_entity')->loadByProperties(['label' => $name]);
-    if (!$entities) {
-      throw new \Exception('The RDF entity could not be found.');
-    }
-
-    /** @var \Drupal\rdf_entity\RdfInterface $rdf */
-    $rdf = reset($entities);
-    if ($rdf->get('provenance_uri')->value !== $provenance_uri) {
+    $entity = $this->loadRdfEntityByName($name);
+    if ($entity->get('provenance_uri')->value !== $provenance_uri) {
       throw new \Exception('The RDF entity did not get created with the proper Provenance URI.');
     }
   }
@@ -161,14 +140,34 @@ class RdfEntityContext extends RawDrupalContext {
    * @Then /^I delete the RDF entity with the name "([^"]*)"$/
    */
   public function iDeleteTheRdfEntityWithTheName($arg1): void {
-    $entities = \Drupal::entityTypeManager()->getStorage('rdf_entity')->loadByProperties(['label' => $arg1]);
-    if ($entities) {
-      $entity = reset($entities);
-      $entity->delete();
-      return;
-    }
+    $entity = $this->loadRdfEntityByName($arg1);
+    $entity->delete();
+  }
 
-    throw new \Exception('RDF entity was not found to be deleted.');
+  /**
+   * Asserts that the current user has access to a given RDF entity.
+   *
+   * @Then I should have :operation access to the RDF entity with the name :name
+   */
+  public function iShouldHaveAccessToTheRdfEntityWithTheName($operation, $name): void {
+    $entity = $this->loadRdfEntityByName($name);
+    if (!$entity->access($operation)) {
+      throw new \Exception('The current user does not have access for this operation and they should.');
+    }
+  }
+
+  /**
+   * Asserts that the current user does not have access to a given RDF entity.
+   *
+   * @Then I should not have :operation access to the RDF entity with the name :name
+   */
+  public function iShouldNotHaveAccessToTheRdfEntityWithTheName($operation, $name): void {
+    $entity = $this->loadRdfEntityByName($name);
+    var_dump('entiy prov: ' . $entity->get('provenance_uri')->value);
+    var_dump('site prov: ' . \Drupal::config('oe_content.settings')->get('provenance_uri'));
+    if ($entity->access($operation)) {
+      throw new \Exception('The current user has access for this operation and they should not..');
+    }
   }
 
   /**
@@ -200,6 +199,44 @@ class RdfEntityContext extends RawDrupalContext {
     $entity = \Drupal::entityTypeManager()->getStorage('rdf_entity')->create($values);
     $entity->save();
     $this->rdfEntities[] = $entity;
+  }
+
+  /**
+   * Loads an RDF entity by name.
+   *
+   * @param string $name
+   *   The name of the entity.
+   *
+   * @return \Drupal\rdf_entity\RdfInterface
+   *   The RDF entity instance.
+   */
+  protected function loadRdfEntityByName($name): RdfInterface {
+    $entities = \Drupal::entityTypeManager()->getStorage('rdf_entity')->loadByProperties(['label' => $name]);
+
+    if (!$entities) {
+      throw new \Exception('RDF entity not found.');
+    }
+
+    return reset($entities);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * To be removed when https://github.com/jhedstrom/drupalextension/issues/498
+   * gets fixed.
+   */
+  public function setConfig($name, $key, $value) {
+    $backup = $this->getDriver()->configGet($name, $key);
+    $this->getDriver()->configSet($name, $key, $value);
+    if (!array_key_exists($name, $this->config)) {
+      $this->config[$name][$key] = $backup;
+      return;
+    }
+
+    if (!array_key_exists($key, $this->config[$name])) {
+      $this->config[$name][$key] = $backup;
+    }
   }
 
 }

--- a/tests/Behat/RdfEntityContext.php
+++ b/tests/Behat/RdfEntityContext.php
@@ -57,6 +57,7 @@ class RdfEntityContext extends ConfigContext {
   public function beforeScenarioRdfCleanUp(BeforeScenarioScope $scope): void {
     // We remove the provenance_uri from the global settings override so that
     // we can test it being set and used in the configuration.
+    // @codingStandardsIgnoreLine
     global $config;
     if (isset($config['oe_content.settings']) && array_key_exists('provenance_uri', $config['oe_content.settings'])) {
       unset($config['oe_content.settings']['provenance_uri']);

--- a/tests/Behat/RdfEntityContext.php
+++ b/tests/Behat/RdfEntityContext.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace Drupal\Tests\oe_content\Behat;
 
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Drupal\DrupalExtension\Context\ConfigContext;
 use Drupal\rdf_entity\RdfInterface;
 use Drupal\user\UserInterface;
@@ -44,36 +43,6 @@ class RdfEntityContext extends ConfigContext {
     foreach ($this->rdfEntities as $rdf) {
       $rdf->delete();
     }
-  }
-
-  /**
-   * Before scenario hook to unset the global provenance_uri.
-   *
-   * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
-   *   The Hook scope.
-   *
-   * @BeforeScenario @rdf-test
-   */
-  public function beforeScenarioRdfCleanUp(BeforeScenarioScope $scope): void {
-    // We remove the provenance_uri from the global settings override so that
-    // we can test it being set and used in the configuration.
-    // @codingStandardsIgnoreLine
-    global $config;
-    if (isset($config['oe_content.settings']) && array_key_exists('provenance_uri', $config['oe_content.settings'])) {
-      unset($config['oe_content.settings']['provenance_uri']);
-    }
-  }
-
-  /**
-   * Before scenario hook sets a default Provenance URI on the site.
-   *
-   * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
-   *   The Hook scope.
-   *
-   * @BeforeScenario @rdf-provenance
-   */
-  public function setDefaultProvenance(BeforeScenarioScope $scope): void {
-    $this->setConfig('oe_content.settings', 'provenance_uri', 'http://example.com');
   }
 
   /**

--- a/tests/Behat/RdfEntityContext.php
+++ b/tests/Behat/RdfEntityContext.php
@@ -61,7 +61,7 @@ class RdfEntityContext extends ConfigContext {
    * @Given the site Provenance URI is set to :uri
    * @And the site Provenance URI is set to :uri
    */
-  public function setSiteProvenanceUri($uri): void {
+  public function setSiteProvenanceUri(string $uri): void {
     $this->setConfig('oe_content.settings', 'provenance_uri', $uri);
   }
 
@@ -73,7 +73,7 @@ class RdfEntityContext extends ConfigContext {
    *
    * @Given I am logged in with a user that can create and view :bundle RDF entities
    */
-  public function assertLoggedInWithRdfEntityTypePermissions($bundle): void {
+  public function assertLoggedInWithRdfEntityTypePermissions(string $bundle): void {
     /** @var \Drupal\rdf_entity\RdfEntityTypeInterface[] $types */
     $types = \Drupal::entityTypeManager()->getStorage('rdf_type')->loadMultiple();
     $permission_map = [];
@@ -118,7 +118,7 @@ class RdfEntityContext extends ConfigContext {
    *
    * @Given I create an :bundle RDF entity with the name :name
    */
-  public function createRdfEntityWithLabel($bundle, $name): void {
+  public function createRdfEntityWithLabel(string $bundle, string $name): void {
     $values = [
       'bundle' => $bundle,
       'label' => $name,
@@ -132,7 +132,7 @@ class RdfEntityContext extends ConfigContext {
    *
    * @Then the Provenance URI of the RDF entity with the name :name should be :provenance_uri
    */
-  public function assertRdfEntityProvenanceUri($name, $provenance_uri): void {
+  public function assertRdfEntityProvenanceUri(string $name, string $provenance_uri): void {
     $entity = $this->loadRdfEntityByName($name);
     if ($entity->get('provenance_uri')->value !== $provenance_uri) {
       throw new \Exception('The RDF entity did not get created with the proper Provenance URI.');
@@ -144,7 +144,7 @@ class RdfEntityContext extends ConfigContext {
    *
    * @Then I delete the RDF entity with the name :name
    */
-  public function deleteRdfEntityByLabel($name): void {
+  public function deleteRdfEntityByLabel(string $name): void {
     $entity = $this->loadRdfEntityByName($name);
     $entity->delete();
   }
@@ -154,7 +154,7 @@ class RdfEntityContext extends ConfigContext {
    *
    * @Then I should have :operation access to the RDF entity with the name :name
    */
-  public function assertAccessToTheRdfEntityWithTheName($operation, $name): void {
+  public function assertAccessToTheRdfEntityWithTheName(string $operation, string $name): void {
     $entity = $this->loadRdfEntityByName($name);
     $current_user = $this->getCurrentUser();
     if (!$entity->access($operation, $current_user)) {
@@ -167,7 +167,7 @@ class RdfEntityContext extends ConfigContext {
    *
    * @Then I should not have :operation access to the RDF entity with the name :name
    */
-  public function assertNoAccessToTheRdfEntityWithTheName($operation, $name): void {
+  public function assertNoAccessToTheRdfEntityWithTheName(string $operation, string $name): void {
     $entity = $this->loadRdfEntityByName($name);
     $current_user = $this->getCurrentUser();
     if ($entity->access($operation, $current_user)) {
@@ -215,7 +215,7 @@ class RdfEntityContext extends ConfigContext {
    * @return \Drupal\rdf_entity\RdfInterface
    *   The RDF entity instance.
    */
-  protected function loadRdfEntityByName($name): RdfInterface {
+  protected function loadRdfEntityByName(string $name): RdfInterface {
     $entities = \Drupal::entityTypeManager()->getStorage('rdf_entity')->loadByProperties(['label' => $name]);
     if (!$entities) {
       throw new \Exception('RDF entity not found.');

--- a/tests/Behat/RdfEntityContext.php
+++ b/tests/Behat/RdfEntityContext.php
@@ -47,6 +47,23 @@ class RdfEntityContext extends ConfigContext {
   }
 
   /**
+   * Before scenario hook to unset the global provenance_uri.
+   *
+   * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
+   *   The Hook scope.
+   *
+   * @BeforeScenario @rdf-test
+   */
+  public function beforeScenarioRdfCleanUp(BeforeScenarioScope $scope): void {
+    // We remove the provenance_uri from the global settings override so that
+    // we can test it being set and used in the configuration.
+    global $config;
+    if (isset($config['oe_content.settings']) && array_key_exists('provenance_uri', $config['oe_content.settings'])) {
+      unset($config['oe_content.settings']['provenance_uri']);
+    }
+  }
+
+  /**
    * Before scenario hook sets a default Provenance URI on the site.
    *
    * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope

--- a/tests/Behat/RdfEntityContext.php
+++ b/tests/Behat/RdfEntityContext.php
@@ -15,6 +15,9 @@ use Drupal\user\UserInterface;
  *
  * We are extending ConfigContext to override the setConfig() method until
  * issue https://github.com/jhedstrom/drupalextension/issues/498 is fixed.
+ *
+ * @todo Extend DrupalRawContext and gather the config context when the above
+ * issue is fixed.
  */
 class RdfEntityContext extends ConfigContext {
 
@@ -243,7 +246,7 @@ class RdfEntityContext extends ConfigContext {
   /**
    * {@inheritdoc}
    *
-   * To be removed when https://github.com/jhedstrom/drupalextension/issues/498
+   * @todo Remove when https://github.com/jhedstrom/drupalextension/issues/498
    * gets fixed.
    */
   public function setConfig($name, $key, $value) {

--- a/tests/features/announcement.feature
+++ b/tests/features/announcement.feature
@@ -4,7 +4,6 @@ Feature: Announcement feature
   As an editor
   I need to be able to create and see announcements
 
-  @rdf-provenance
   Scenario: Create announcement
     Given I am logged in with a user that can create and view "Announcement" RDF entities
     And I visit "/rdf_entity/add/oe_announcement"

--- a/tests/features/event.feature
+++ b/tests/features/event.feature
@@ -4,7 +4,6 @@ Feature: Event feature
   As an editor
   I need to be able to create and see events
 
-  @rdf-provenance
   Scenario: Create event
     Given I am logged in with a user that can create and view "Event" RDF entities
     And I visit "/rdf_entity/add/oe_event"

--- a/tests/features/provenance_uri.feature
+++ b/tests/features/provenance_uri.feature
@@ -22,4 +22,4 @@ Feature: Provenance feature
     Then I should not have "edit" access to the RDF entity with the name "Test Provenance Access One"
     And I should not have "delete" access to the RDF entity with the name "Test Provenance Access One"
     And I should have "edit" access to the RDF entity with the name "Test Provenance Access Two"
-    And I should have "edit" access to the RDF entity with the name "Test Provenance Access Two"
+    And I should have "delete" access to the RDF entity with the name "Test Provenance Access Two"

--- a/tests/features/provenance_uri.feature
+++ b/tests/features/provenance_uri.feature
@@ -1,4 +1,4 @@
-@api @run
+@api
 # This is needed due to issues with the Kernel testing of the RDF entity module
 # in Drupal 8.6.
 Feature: Provenance feature
@@ -6,11 +6,11 @@ Feature: Provenance feature
   As a content editor
   I should be able create RDF entities with their provenance URIs pre filled
 
-#  @rdf-test
-#  Scenario: Provenance URI is pre-filled when creating an RDF entity
-#    Given the site Provenance URI is set to "http://example-provenance.com"
-#    And I create an "Announcement" RDF entity with the name "Test Provenance"
-#    Then the Provenance URI of the RDF entity with the name "Test Provenance" should be "http://example-provenance.com"
+  @rdf-test
+  Scenario: Provenance URI is pre-filled when creating an RDF entity
+    Given the site Provenance URI is set to "http://example-provenance.com"
+    And I create an "Announcement" RDF entity with the name "Test Provenance"
+    Then the Provenance URI of the RDF entity with the name "Test Provenance" should be "http://example-provenance.com"
 
   @rdf-test
   Scenario: Access to manage RDF entities needs to take the provenance URI into account.

--- a/tests/features/provenance_uri.feature
+++ b/tests/features/provenance_uri.feature
@@ -9,3 +9,15 @@ Feature: Provenance feature
     Given the site Provenance URI is set to "http://example-provenance.com"
     And I create an "Announcement" RDF entity with the name "Test Provenance"
     Then the Provenance URI of the RDF entity with the name "Test Provenance" should be "http://example-provenance.com"
+
+  @rdf-test
+  Scenario: Access to manage RDF entities needs to take the provenance URI into account.
+    Given I am logged in with a user that can create and view "Announcement" RDF entities
+    And the site Provenance URI is set to "http://example-provenance.com"
+    And I create an "Announcement" RDF entity with the name "Test Provenance Access One"
+    And the site Provenance URI is set to "http://example-provenance-another-site.com"
+    And I create an "Announcement" RDF entity with the name "Test Provenance Access Two"
+    Then I should not have "edit" access to the RDF entity with the name "Test Provenance Access One"
+    And I should not have "delete" access to the RDF entity with the name "Test Provenance Access One"
+    And I should have "edit" access to the RDF entity with the name "Test Provenance Access Two"
+    And I should have "edit" access to the RDF entity with the name "Test Provenance Access Two"


### PR DESCRIPTION
## OPENEUROPA-1111

### Description

* Access check on edit/delete
* Test
* Temporary extension of the ConfigContext until a PR gets merged in drupal extension project

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

