### PR TITLE
OPENEUROPA-1145: Map the translation fields of all content types

### DIFF
--- a/modules/oe_content_announcement/config/install/rdf_entity.mapping.rdf_entity.oe_announcement.yml
+++ b/modules/oe_content_announcement/config/install/rdf_entity.mapping.rdf_entity.oe_announcement.yml
@@ -39,12 +39,12 @@ base_fields_mapping:
       format: ''
   langcode:
     value:
-      predicate: ''
-      format: ''
+      predicate: 'http://europa.eu/langcode'
+      format: 'xsd:string'
   default_langcode:
     value:
-      predicate: ''
-      format: ''
+      predicate: 'http://europa.eu/default_langcode'
+      format: 'xsd:boolean'
   provenance_uri:
     value:
       predicate: 'http://europa.eu/provenance_uri'

--- a/modules/oe_content_event/config/install/rdf_entity.mapping.rdf_entity.oe_event.yml
+++ b/modules/oe_content_event/config/install/rdf_entity.mapping.rdf_entity.oe_event.yml
@@ -39,12 +39,12 @@ base_fields_mapping:
       format: ''
   langcode:
     value:
-      predicate: ''
-      format: ''
+      predicate: 'http://europa.eu/langcode'
+      format: 'xsd:string'
   default_langcode:
     value:
-      predicate: ''
-      format: ''
+      predicate: 'http://europa.eu/default_langcode'
+      format: 'xsd:boolean'
   provenance_uri:
     value:
       predicate: 'http://europa.eu/provenance_uri'


### PR DESCRIPTION
## OPENEUROPA-1145

### Description

Added RDF mapping for 

* langcode (string)
* default_langcode (bool)

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

