### PR TITLE
OPENEUROPA-1161: Apply patches to rdf_entity instead of using GitHub fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^7.1",
         "drupal/core": "~8.6@alpha",
         "drupal/field_group": "^1.0",
-        "drupal/rdf_entity": "dev-DEV",
+        "drupal/rdf_entity": "dev-1.x",
         "easyrdf/easyrdf": "0.10.0-alpha1 as 0.9.2"
     },
     "require-dev": {
@@ -54,6 +54,13 @@
     "extra": {
         "composer-exit-on-patch-failure": true,
         "enable-patching": true,
+        "patches": {
+            "drupal/rdf_entity": {
+                "GH-63: Paginating the term list page - https://github.com/ec-europa/rdf_entity/pull/64": "https://patch-diff.githubusercontent.com/raw/ec-europa/rdf_entity/pull/64.patch",
+                "GH-61 - Fixing RDF taxonomy access bug - https://github.com/ec-europa/rdf_entity/pull/62": "https://patch-diff.githubusercontent.com/raw/ec-europa/rdf_entity/pull/62.patch",
+                "GH-59: Multi-column field support (for cardinality 0) - https://github.com/ec-europa/rdf_entity/pull/60": "https://patch-diff.githubusercontent.com/raw/ec-europa/rdf_entity/pull/60.patch"
+            }
+        },
         "installer-paths": {
             "build/core": ["type:drupal-core"],
             "build/profiles/contrib/{$name}": ["type:drupal-profile"],


### PR DESCRIPTION
## OPENEUROPA-1161

### Description

In oe_content we use rdf_entity fork on openeuropa organisation, in doing so we specify an alternative repository from where to fetch that fork in the project's composer.json: it turns out that such a repository is not considered when using the component on a site

The scope of this PR is to switch to use patches which are, instead, applied when installing the component.


