### PR TITLE
OPENEUROPA-1191: OE Content field formatters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,10 +43,6 @@
     },
     "repositories": [
         {
-            "type": "git",
-            "url": "https://github.com/openeuropa/rdf_entity"
-        },
-        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }
@@ -57,8 +53,7 @@
         "patches": {
             "drupal/rdf_entity": {
                 "GH-63: Paginating the term list page - https://github.com/ec-europa/rdf_entity/pull/64": "https://patch-diff.githubusercontent.com/raw/ec-europa/rdf_entity/pull/64.patch",
-                "GH-61 - Fixing RDF taxonomy access bug - https://github.com/ec-europa/rdf_entity/pull/62": "https://patch-diff.githubusercontent.com/raw/ec-europa/rdf_entity/pull/62.patch",
-                "GH-59: Multi-column field support (for cardinality 0) - https://github.com/ec-europa/rdf_entity/pull/60": "https://patch-diff.githubusercontent.com/raw/ec-europa/rdf_entity/pull/60.patch"
+                "GH-61 - Fixing RDF taxonomy access bug - https://github.com/ec-europa/rdf_entity/pull/62": "https://patch-diff.githubusercontent.com/raw/ec-europa/rdf_entity/pull/62.patch"
             }
         },
         "installer-paths": {

--- a/modules/oe_content_announcement/config/install/core.entity_view_display.rdf_entity.oe_announcement.default.yml
+++ b/modules/oe_content_announcement/config/install/core.entity_view_display.rdf_entity.oe_announcement.default.yml
@@ -22,10 +22,9 @@ content:
   oe_announcement_department:
     weight: 7
     label: above
-    settings:
-      link: true
+    settings: {  }
     third_party_settings: {  }
-    type: entity_reference_label
+    type: rdf_entity_reference_department_url
     region: content
   oe_announcement_location:
     weight: 6

--- a/modules/oe_content_announcement/oe_content_announcement.info.yml
+++ b/modules/oe_content_announcement/oe_content_announcement.info.yml
@@ -1,4 +1,4 @@
-name: OE Content Announcement
+name: OpenEuropa Announcement Content
 description: Provides the Announcement RDF entity type
 core: 8.x
 type: module

--- a/modules/oe_content_event/config/install/core.entity_view_display.rdf_entity.oe_event.default.yml
+++ b/modules/oe_content_event/config/install/core.entity_view_display.rdf_entity.oe_event.default.yml
@@ -25,10 +25,9 @@ content:
   oe_event_organiser:
     weight: 10
     label: above
-    settings:
-      link: true
+    settings: {  }
     third_party_settings: {  }
-    type: entity_reference_label
+    type: rdf_entity_reference_department_url
     region: content
   oe_event_subject:
     weight: 8

--- a/oe_content.services.yml
+++ b/oe_content.services.yml
@@ -3,3 +3,8 @@ services:
     class: Drupal\oe_content\EventSubscriber\RdfAdminRouteSubscriber
     tags:
       - { name: event_subscriber }
+  oe_content.rdf_entity_redirect:
+    class: Drupal\oe_content\EventSubscriber\RdfEntityRedirectSubscriber
+    arguments: ['@entity_type.manager']
+    tags:
+      - { name: event_subscriber }

--- a/src/EventSubscriber/RdfEntityRedirectSubscriber.php
+++ b/src/EventSubscriber/RdfEntityRedirectSubscriber.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_content\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\rdf_entity\RdfInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Redirects from the RDF URI to the canonical URL of the entity.
+ *
+ * @todo remove this when OPENEUROPA-1194 is in.
+ */
+class RdfEntityRedirectSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs RdfEntityRedirectSubscriber.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    $events[KernelEvents::REQUEST] = 'onRequest';
+    return $events;
+  }
+
+  /**
+   * Performs the redirect.
+   *
+   * In case the URI of an RDF entity is requested, redirect to the canonical
+   * URL of that entity if possible.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+   *   The event.
+   */
+  public function onRequest(GetResponseEvent $event): void {
+    $request = $event->getRequest();
+    $path = $request->getPathInfo();
+    $exploded = explode('/', trim($path, '/'));
+    if (count($exploded) !== 3 || $exploded[0] !== 'rdf_entity') {
+      return;
+    }
+
+    global $base_url;
+    $base = $base_url;
+    $uri = $base . $path;
+    $entity = $this->entityTypeManager->getStorage('rdf_entity')->load($uri);
+    if (!$entity instanceof RdfInterface) {
+      return;
+    }
+
+    $url = $entity->toUrl();
+    $response = new RedirectResponse($url->toString());
+    $event->setResponse($response);
+    if ($request->query->has('destination')) {
+      $request->query->remove('destination');
+    }
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/RdfEntityReferenceAbsoluteUrlFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/RdfEntityReferenceAbsoluteUrlFormatter.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_content\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Url;
+use Drupal\rdf_entity\RdfInterface;
+
+/**
+ * Plugin implementation of the 'rdf_entity_reference_absolute_url' formatter.
+ *
+ * @todo write Kernel Test as soon as RDF entity module works with Drupal 8.6.
+ *
+ * @FieldFormatter(
+ *   id = "rdf_entity_reference_absolute_url",
+ *   label = @Translation("RDF Entity Reference Absolute URL"),
+ *   field_types = {
+ *     "entity_reference"
+ *   }
+ * )
+ */
+class RdfEntityReferenceAbsoluteUrlFormatter extends RdfEntityReferenceLabelFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+
+    $summary[] = [
+      '#markup' => $this->t('Linked label to the URI of the RDF entity.'),
+    ];
+
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEntitiesToView(EntityReferenceFieldItemListInterface $items, $langcode): array {
+    $entities = parent::getEntitiesToView($items, $langcode);
+
+    // Only allow RDF entities.
+    $entities = array_filter($entities, function (EntityInterface $entity) {
+      return $entity instanceof RdfInterface;
+    });
+
+    return $entities;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getUrlForEntity(EntityInterface $entity): Url {
+    $uri = $entity->id();
+    return Url::fromUri($uri);
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/RdfEntityReferenceDepartmentUrlFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/RdfEntityReferenceDepartmentUrlFormatter.php
@@ -95,7 +95,7 @@ class RdfEntityReferenceDepartmentUrlFormatter extends RdfEntityReferenceLabelFo
 
     // Only allow RDF taxonomy entities.
     $entities = array_filter($entities, function (EntityInterface $entity) {
-      return $entity instanceof TermInterface;
+      return $entity instanceof TermInterface && $entity->bundle() === 'corporate_bodies';
     });
 
     return $entities;

--- a/src/Plugin/Field/FieldFormatter/RdfEntityReferenceDepartmentUrlFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/RdfEntityReferenceDepartmentUrlFormatter.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_content\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Url;
+use Drupal\taxonomy\TermInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the 'rdf_entity_reference_department_url' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "rdf_entity_reference_department_url",
+ *   label = @Translation("RDF Entity Reference Department URL"),
+ *   field_types = {
+ *     "entity_reference"
+ *   }
+ * )
+ */
+class RdfEntityReferenceDepartmentUrlFormatter extends RdfEntityReferenceLabelFormatterBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a RdfEntityReferenceDepartmentUrlFormatter object.
+   *
+   * @param string $plugin_id
+   *   The plugin_id for the formatter.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the formatter is associated.
+   * @param array $settings
+   *   The formatter settings.
+   * @param string $label
+   *   The formatter label display setting.
+   * @param string $view_mode
+   *   The view mode.
+   * @param array $third_party_settings
+   *   Any third party settings.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, EntityTypeManagerInterface $entityTypeManager) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+
+    $summary[] = [
+      '#markup' => $this->t('Linked label to the Department RDF entity canonical URL if one exists.'),
+    ];
+
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEntitiesToView(EntityReferenceFieldItemListInterface $items, $langcode): array {
+    $entities = parent::getEntitiesToView($items, $langcode);
+
+    // Only allow RDF taxonomy entities.
+    $entities = array_filter($entities, function (EntityInterface $entity) {
+      return $entity instanceof TermInterface;
+    });
+
+    return $entities;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getUrlForEntity(EntityInterface $entity): Url {
+    $uris = $this->entityTypeManager->getStorage('rdf_entity')->getQuery()
+      ->condition('rid', 'oe_department')
+      ->condition('oe_department_name', $entity->id())
+      ->execute();
+
+    if (!$uris) {
+      return $entity->toUrl()->setAbsolute(TRUE);
+    }
+
+    // Normally there should only be one Department instance.
+    $uri = reset($uris);
+    return Url::fromUri($uri);
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/RdfEntityReferenceLabelFormatterBase.php
+++ b/src/Plugin/Field/FieldFormatter/RdfEntityReferenceLabelFormatterBase.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_content\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceFormatterBase;
+use Drupal\Core\Url;
+
+/**
+ * Base class for the RDF entity reference label field formatters.
+ */
+abstract class RdfEntityReferenceLabelFormatterBase extends EntityReferenceFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode): array {
+    $elements = [];
+
+    foreach ($this->getEntitiesToView($items, $langcode) as $delta => $entity) {
+      $elements[$delta] = [
+        '#cache' => [
+          'tags' => $entity->getCacheTags(),
+        ],
+      ];
+
+      $label = $entity->label();
+      try {
+        $url = $this->getUrlForEntity($entity);
+      }
+      catch (\InvalidArgumentException $e) {
+        $elements[$delta]['#plain_text'] = $label;
+        return $elements;
+      }
+
+      if ($entity->isNew()) {
+        $elements[$delta]['#plain_text'] = $label;
+        return $elements;
+      }
+
+      $elements[$delta] = [
+        '#type' => 'link',
+        '#title' => $label,
+        '#url' => $url,
+      ];
+
+      if (!empty($items[$delta]->_attributes)) {
+        $elements[$delta]['#options'] += ['attributes' => []];
+        $elements[$delta]['#options']['attributes'] += $items[$delta]->_attributes;
+        unset($items[$delta]->_attributes);
+      }
+
+    }
+
+    return $elements;
+  }
+
+  /**
+   * Returns the URL to use for the entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The RDF or Taxonomy Term entity.
+   *
+   * @return \Drupal\Core\Url
+   *   The URL object.
+   */
+  abstract protected function getUrlForEntity(EntityInterface $entity): Url;
+
+}

--- a/tests/Behat/RdfEntityContext.php
+++ b/tests/Behat/RdfEntityContext.php
@@ -207,7 +207,7 @@ class RdfEntityContext extends ConfigContext {
     $url = $base_url . $url;
 
     if ($path !== $url) {
-      throw new \Exception(sprintf('The current URL of %s does not match the URL of the entity "%s" which is %s', $path, $name, $url->toString()));
+      throw new \Exception(sprintf('The current URL of %s does not match the URL of the entity "%s" which is %s', $path, $name, $url));
     }
   }
 

--- a/tests/features/department.feature
+++ b/tests/features/department.feature
@@ -20,3 +20,10 @@ Feature: Department feature
     And I should see the link "information technology industry"
     Then I delete the RDF entity with the name "Directorate-General for Informatics"
 
+  @rdf-test
+  Scenario: Department reference fields should link to Department pages
+    Given I am logged in with a user that can create and view "Announcement" RDF entities
+    And I create an "Department" RDF entity with the name "Directorate-General for Informatics"
+    And I visit an announcement page that links to the department "Directorate-General for Informatics" taxonomy term
+    And I click "Directorate-General for Informatics"
+    Then I should be on the "Directorate-General for Informatics" RDF entity page


### PR DESCRIPTION
## OPENEUROPA-1191

### Description

* Created the 2 formatters
* Wrote a Behat test for the second formatter
* TODO - write kernel test for the first formatter when RDF entity works with Drupal 8.6

### Change log

- Added: 2 formatters
- Added: Behat test for the second formatter

### Commands

```sh
[Insert commands here]

```

