### PR TITLE
OPENEUROPA-1200: Map text format in oe_content on all fields which use it

### DIFF
--- a/modules/oe_content_announcement/config/install/field.storage.rdf_entity.oe_announcement_body.yml
+++ b/modules/oe_content_announcement/config/install/field.storage.rdf_entity.oe_announcement_body.yml
@@ -11,8 +11,8 @@ third_party_settings:
         predicate: 'http://schema.org/articleBody'
         format: t_literal
       format:
-        predicate: ''
-        format: no_format
+        predicate: 'http://europa.eu/oe_announcement_body/format'
+        format: 'xsd:string'
 id: rdf_entity.oe_announcement_body
 field_name: oe_announcement_body
 entity_type: rdf_entity

--- a/modules/oe_content_announcement/config/install/field.storage.rdf_entity.oe_announcement_description.yml
+++ b/modules/oe_content_announcement/config/install/field.storage.rdf_entity.oe_announcement_description.yml
@@ -11,8 +11,8 @@ third_party_settings:
         predicate: 'http://schema.org/description'
         format: t_literal
       format:
-        predicate: ''
-        format: no_format
+        predicate: 'http://europa.eu/oe_announcement_description/format'
+        format: 'xsd:string'
 id: rdf_entity.oe_announcement_description
 field_name: oe_announcement_description
 entity_type: rdf_entity

--- a/modules/oe_content_announcement/config/install/field.storage.rdf_entity.oe_announcement_introduction.yml
+++ b/modules/oe_content_announcement/config/install/field.storage.rdf_entity.oe_announcement_introduction.yml
@@ -11,8 +11,8 @@ third_party_settings:
         predicate: 'http://schema.org/alternativeHeadline'
         format: t_literal
       format:
-        predicate: ''
-        format: no_format
+        predicate: 'http://europa.eu/oe_announcement_introduction/format'
+        format: 'xsd:string'
 id: rdf_entity.oe_announcement_introduction
 field_name: oe_announcement_introduction
 entity_type: rdf_entity

--- a/modules/oe_content_department/config/install/field.storage.rdf_entity.oe_department_description.yml
+++ b/modules/oe_content_department/config/install/field.storage.rdf_entity.oe_department_description.yml
@@ -11,8 +11,8 @@ third_party_settings:
         predicate: 'http://schema.org/description'
         format: t_literal
       format:
-        predicate: ''
-        format: no_format
+        predicate: 'http://europa.eu/oe_department_description/format'
+        format: 'xsd:string'
 id: rdf_entity.oe_department_description
 field_name: oe_department_description
 entity_type: rdf_entity

--- a/modules/oe_content_department/config/install/field.storage.rdf_entity.oe_department_tasks_description.yml
+++ b/modules/oe_content_department/config/install/field.storage.rdf_entity.oe_department_tasks_description.yml
@@ -11,8 +11,8 @@ third_party_settings:
         predicate: 'http://schema.org/knowsAbout'
         format: t_literal
       format:
-        predicate: ''
-        format: no_format
+        predicate: 'http://europa.eu/oe_department_tasks_description/format'
+        format: 'xsd:string'
 id: rdf_entity.oe_department_tasks_description
 field_name: oe_department_tasks_description
 entity_type: rdf_entity

--- a/modules/oe_content_event/config/install/field.storage.rdf_entity.oe_event_description.yml
+++ b/modules/oe_content_event/config/install/field.storage.rdf_entity.oe_event_description.yml
@@ -11,8 +11,8 @@ third_party_settings:
         predicate: 'https://schema.org/description'
         format: t_literal
       format:
-        predicate: ''
-        format: no_format
+        predicate: 'http://europa.eu/oe_event_description/format'
+        format: 'xsd:string'
 id: rdf_entity.oe_event_description
 field_name: oe_event_description
 entity_type: rdf_entity

--- a/modules/oe_content_event/config/install/field.storage.rdf_entity.oe_event_introduction.yml
+++ b/modules/oe_content_event/config/install/field.storage.rdf_entity.oe_event_introduction.yml
@@ -11,8 +11,8 @@ third_party_settings:
         predicate: 'https://schema.org/text'
         format: t_literal
       format:
-        predicate: ''
-        format: no_format
+        predicate: 'http://europa.eu/oe_event_introduction/format'
+        format: 'xsd:string'
 id: rdf_entity.oe_event_introduction
 field_name: oe_event_introduction
 entity_type: rdf_entity


### PR DESCRIPTION
## OPENEUROPA-1200

### Description

Added field mappings for the fields which use text formats.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

