### PR TITLE
OPENEUROPA-1199: Removing the patch for RDF working with Drupal 8.6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,7 @@
         "patches": {
             "drupal/rdf_entity": {
                 "GH-63: Paginating the term list page - https://github.com/ec-europa/rdf_entity/pull/64": "https://patch-diff.githubusercontent.com/raw/ec-europa/rdf_entity/pull/64.patch",
-                "GH-61 - Fixing RDF taxonomy access bug - https://github.com/ec-europa/rdf_entity/pull/62": "https://patch-diff.githubusercontent.com/raw/ec-europa/rdf_entity/pull/62.patch",
-                "Run on 8.6.x - https://github.com/ec-europa/rdf_entity/pull/65": "https://patch-diff.githubusercontent.com/raw/ec-europa/rdf_entity/pull/65.patch"
+                "GH-61 - Fixing RDF taxonomy access bug - https://github.com/ec-europa/rdf_entity/pull/62": "https://patch-diff.githubusercontent.com/raw/ec-europa/rdf_entity/pull/62.patch"
             }
         },
         "installer-paths": {

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -46,10 +46,6 @@ drupal:
 commands:
   drupal:site-setup:
     - { task: "symlink", from: "../../..", to: "${drupal.root}/modules/custom/oe_content" }
-    # @todo: remove after this PR gets in https://github.com/ec-europa/rdf_entity/pull/65.
-    - task: "append"
-      file: "build/sites/default/default.settings.php"
-      text: "\n$class_loader->addClassMap(['Drupal\\Driver\\Database\\sparql\\Connection' => $app_root . '/modules/contrib/rdf_entity/driver/sparql/Connection.php']);\n"
     - { task: "run", command: "drupal:drush-setup" }
     - { task: "run", command: "drupal:settings-setup" }
     - { task: "run", command: "setup:phpunit" }


### PR DESCRIPTION
## OPENEUROPA-1199

### Description

The PR https://github.com/ec-europa/rdf_entity/pull/65 has been merged so we can remove the patch.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

