### PR TITLE
OPENEUROPA-1188: Refactoring the department referencing to a dispatcher.

### DIFF
--- a/oe_content.services.yml
+++ b/oe_content.services.yml
@@ -8,3 +8,8 @@ services:
     arguments: ['@entity_type.manager']
     tags:
       - { name: event_subscriber }
+  oe_content.default_department_referencing_subscriber:
+    class: Drupal\oe_content\EventSubscriber\DefaultDepartmentReferencingSubscriber
+    arguments: ['@entity_type.manager']
+    tags:
+      - { name: event_subscriber }

--- a/src/Event/DepartmentReferencingEvent.php
+++ b/src/Event/DepartmentReferencingEvent.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_content\Event;
+
+use Drupal\rdf_entity\RdfInterface;
+use Drupal\taxonomy\TermInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event class for department referencing dispatched events.
+ */
+class DepartmentReferencingEvent extends Event {
+
+  /**
+   * The event name.
+   */
+  const EVENT = 'oe_content.department_referencing_event';
+
+  /**
+   * The department term.
+   *
+   * @var \Drupal\taxonomy\TermInterface
+   */
+  protected $term;
+
+  /**
+   * The oe_department RDF entity mapped to the department term.
+   *
+   * @var \Drupal\rdf_entity\RdfInterface
+   */
+  protected $rdfEntity = NULL;
+
+  /**
+   * DepartmentReferencingEvent constructor.
+   *
+   * @param \Drupal\taxonomy\TermInterface $term
+   *   The department taxonomy term.
+   */
+  public function __construct(TermInterface $term) {
+    $this->term = $term;
+  }
+
+  /**
+   * Returns the department term.
+   *
+   * @return \Drupal\taxonomy\TermInterface
+   *   The term.
+   */
+  public function getTerm(): TermInterface {
+    return $this->term;
+  }
+
+  /**
+   * Returns the department RDF entity.
+   *
+   * @return \Drupal\rdf_entity\RdfInterface|null
+   *   The entity.
+   */
+  public function getRdfEntity():? RdfInterface {
+    return $this->rdfEntity;
+  }
+
+  /**
+   * Sets the department RDF entity.
+   *
+   * @param \Drupal\rdf_entity\RdfInterface $rdf_entity
+   *   The entity.
+   */
+  public function setRdfEntity(RdfInterface $rdf_entity): void {
+    $this->rdfEntity = $rdf_entity;
+  }
+
+}

--- a/src/EventSubscriber/DefaultDepartmentReferencingSubscriber.php
+++ b/src/EventSubscriber/DefaultDepartmentReferencingSubscriber.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_content\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\oe_content\Event\DepartmentReferencingEvent;
+use Drupal\rdf_entity\RdfInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Default subscriber to the department referencing events.
+ *
+ * It looks in the current triple store for a matching department RDF entity.
+ */
+class DefaultDepartmentReferencingSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a DefaultDepartmentReferencingSubscriber.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      DepartmentReferencingEvent::EVENT => 'getDepartment',
+    ];
+  }
+
+  /**
+   * Looks in the current triple store for a matching department.
+   *
+   * @param \Drupal\oe_content\Event\DepartmentReferencingEvent $event
+   *   The event.
+   */
+  public function getDepartment(DepartmentReferencingEvent $event): void {
+    if ($event->getRdfEntity() instanceof RdfInterface) {
+      // If some other subscriber already provided an entity, we don't need to
+      // do anything. We are just a fallback.
+      return;
+    }
+
+    $term = $event->getTerm();
+    $uris = $this->entityTypeManager->getStorage('rdf_entity')->getQuery()
+      ->condition('rid', 'oe_department')
+      ->condition('oe_department_name', $term->id())
+      ->execute();
+
+    if (!$uris) {
+      return;
+    }
+
+    // Normally there should only be 1.
+    $uri = reset($uris);
+    /** @var \Drupal\rdf_entity\RdfInterface $entity */
+    $entity = $this->entityTypeManager->getStorage('rdf_entity')->load($uri);
+    $event->setRdfEntity($entity);
+  }
+
+}


### PR DESCRIPTION
## OPENEUROPA-1188

### Description

In order to allow others to provide a way to map a department rdf entity to a department term, we refactored the formatter to dispatch an event. This case was made apparent by the use of the content broker in the demo site which altered the query and disallowed departments from being queryable on certain sites.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

