### PR TITLE
OPENEUROPA-1384: Removing legacy code from when RDF Taxonomy was used.

### DIFF
--- a/oe_content.module
+++ b/oe_content.module
@@ -14,7 +14,6 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\rdf_entity\Entity\Rdf;
-use Drupal\Core\Database\Query\AlterableInterface;
 
 /**
  * Implements hook_entity_base_field_info().
@@ -77,32 +76,4 @@ function oe_content_rdf_entity_access(EntityInterface $entity, string $operation
 
   $provenance_uri = \Drupal::config('oe_content.settings')->get('provenance_uri');
   return $entity->get('provenance_uri')->value === $provenance_uri ? AccessResult::neutral() : AccessResult::forbidden();
-}
-
-/**
- * Implements hook_ENTITY_TYPE_storage_load().
- */
-function oe_content_taxonomy_term_storage_load(array $entities): void {
-  // Taxonomy terms have a status field for handling publishing state. We need
-  // to default to TRUE for all terms because the RDF storage which handles
-  // taxonomy does not know about Status.
-  // @todo Remove once we refactor away from RDF taxonomy.
-  foreach ($entities as $entity) {
-    $entity->set('status', TRUE);
-  }
-}
-
-/**
- * Implements hook_query_QUERY_TAG_alter() for the taxonomy_term_access tag.
- */
-function oe_content_query_taxonomy_term_access_alter(AlterableInterface $query) {
-  // We need to remove the Status condition for RDF taxonomies when they are
-  // queried. Same reason as oe_content_taxonomy_term_load().
-  // @todo Remove once we refactor away from RDF taxonomy.
-  $conditions = &$query->conditions();
-  foreach ($conditions as $key => $condition) {
-    if ($condition['field'] === 'status') {
-      unset($conditions[$key]);
-    }
-  }
 }


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

This is some left over code from when the RDF taxonomy was used. Since we moved to RDF SKOS, this is no longer needed. And it breaks stuff.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

