### PR TITLE
OPENEUROPA-1520: Use drupal core.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
+        "drupal/core": "^8.6",
         "drupal/field_group": "^1.0",
         "drupal/rdf_entity": "dev-1.x",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",
-        "openeuropa/drupal-core-require": "^8.6",
         "openeuropa/rdf_skos": "dev-master",
         "php": "^7.1"
     },


### PR DESCRIPTION
## OPENEUROPA-1520

### Description

Remove drupal-core-require and use drupal/core
### Change log

- Added:
- Changed: Remove drupal-core-require and use drupal/core
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

