### PR TITLE
OPENEUROPA-1609 Fix behat.yml.dist to use drupal-extension properly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenEuropa Content
 
+**This component is in active development. It is not ready to be used.**
+
 This is a Drupal module that contains the European Commission corporate entity types.
 
 The main entity type is the RDF Entity which has the following bundles:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -14,7 +14,7 @@ default:
               department creation: 'rdf_entity/add/oe_department'
               event creation: 'rdf_entity/add/oe_event'
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       goutte: ~
       selenium2: ~
       javascript_session: selenium2

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "composer/installers": "^1.2",
         "drupal/config_devel": "~1.2",
-        "drupal/drupal-extension": "^4.0.0@alpha",
+        "drupal/drupal-extension": "^4.0",
         "drupal-composer/drupal-scaffold": "^2.2",
         "drush/drush": "^9",
         "openeuropa/behat-transformation-context" : "~0.1",


### PR DESCRIPTION
After moving from drupal-extension v3 to v4 Drupal\MinkExtension has to be used.