### PR TITLE
OPENEUROPA-1679: Remove preview mode from content types.

### DIFF
--- a/modules/oe_content_news/config/install/node.type.oe_news.yml
+++ b/modules/oe_content_news/config/install/node.type.oe_news.yml
@@ -6,5 +6,5 @@ type: oe_news
 description: ''
 help: ''
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: true

--- a/modules/oe_content_page/config/install/node.type.oe_page.yml
+++ b/modules/oe_content_page/config/install/node.type.oe_page.yml
@@ -6,5 +6,5 @@ type: oe_page
 description: ''
 help: ''
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: true


### PR DESCRIPTION
## OPENEUROPA-1679

### Description

Remove preview mode from content types.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed: Preview mode from content types
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

