### PR TITLE
OPENEUROPA-1690: Adding Skos Concept reference field config.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "drupal/core": "^8.6",
         "drupal/field_group": "^1.0",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",
-        "openeuropa/rdf_skos": "dev-master",
+        "openeuropa/rdf_skos": "dev-OPENEUROPA-1690",
         "openeuropa/oe_media": "~0.2.0",
         "php": "^7.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "drupal/core": "^8.6",
         "drupal/field_group": "^1.0",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",
-        "openeuropa/rdf_skos": "dev-OPENEUROPA-1690",
+        "openeuropa/rdf_skos": "dev-master",
         "openeuropa/oe_media": "~0.2.0",
         "php": "^7.1"
     },

--- a/modules/oe_content_news/config/install/field.field.node.oe_news.oe_news_author.yml
+++ b/modules/oe_content_news/config/install/field.field.node.oe_news.oe_news_author.yml
@@ -25,4 +25,10 @@ settings:
     auto_create: 0
     concept_schemes:
       - 'http://publications.europa.eu/resource/authority/corporate-body'
+    field:
+      field_name: oe_news_author
+      entity_type: node
+      bundle: oe_news
+      concept_schemes:
+        - 'http://publications.europa.eu/resource/authority/corporate-body'
 field_type: skos_concept_entity_reference

--- a/modules/oe_content_news/config/install/field.field.node.oe_news.oe_news_subject.yml
+++ b/modules/oe_content_news/config/install/field.field.node.oe_news.oe_news_subject.yml
@@ -25,4 +25,10 @@ settings:
     auto_create: 0
     concept_schemes:
       - 'http://eurovoc.europa.eu/100141'
+    field:
+      field_name: oe_news_subject
+      entity_type: node
+      bundle: oe_news
+      concept_schemes:
+        - 'http://eurovoc.europa.eu/100141'
 field_type: skos_concept_entity_reference

--- a/modules/oe_content_page/config/install/field.field.node.oe_page.oe_page_author.yml
+++ b/modules/oe_content_page/config/install/field.field.node.oe_page.oe_page_author.yml
@@ -25,4 +25,10 @@ settings:
     auto_create: 0
     concept_schemes:
       - 'http://publications.europa.eu/resource/authority/corporate-body'
+    field:
+      field_name: oe_page_author
+      entity_type: node
+      bundle: oe_page
+      concept_schemes:
+        - 'http://publications.europa.eu/resource/authority/corporate-body'
 field_type: skos_concept_entity_reference

--- a/modules/oe_content_page/config/install/field.field.node.oe_page.oe_page_subject.yml
+++ b/modules/oe_content_page/config/install/field.field.node.oe_page.oe_page_subject.yml
@@ -25,4 +25,10 @@ settings:
     auto_create: 0
     concept_schemes:
       - 'http://eurovoc.europa.eu/100141'
+    field:
+      field_name: oe_page_subject
+      entity_type: node
+      bundle: oe_page
+      concept_schemes:
+        - 'http://eurovoc.europa.eu/100141'
 field_type: skos_concept_entity_reference

--- a/oe_content.module
+++ b/oe_content.module
@@ -70,6 +70,14 @@ function oe_content_entity_base_field_info(EntityTypeInterface $entity_type) {
         'concept_schemes' => [
           'http://publications.europa.eu/resource/authority/corporate-body',
         ],
+        'field' => [
+          'field_name' => 'oe_content_content_owner',
+          'entity_type' => 'node',
+          'bundle' => NULL,
+          'concept_schemes' => [
+            'http://publications.europa.eu/resource/authority/corporate-body',
+          ],
+        ],
       ],
       'default_value' => 0,
     ])

--- a/src/PublicationsOfficeSkosGraphSetup.php
+++ b/src/PublicationsOfficeSkosGraphSetup.php
@@ -36,6 +36,7 @@ class PublicationsOfficeSkosGraphSetup {
   protected function getGraphInfo(): array {
     return [
       'corporate_body' => 'http://publications.europa.eu/resource/authority/corporate-body',
+      'corporate_body_classification' => 'http://publications.europa.eu/resource/dataset/corporate-body-classification',
       'target_audience' => 'http://publications.europa.eu/resource/authority/target-audience',
       'organisation_type' => 'http://publications.europa.eu/resource/authority/organization-type',
       'resource_type' => 'http://publications.europa.eu/resource/authority/resource-type',


### PR DESCRIPTION
## OPENEUROPA-1690

### Description

Exported the config for the Concept reference fields. See https://github.com/openeuropa/rdf_skos/pull/10 for why.



