### PR TITLE
OPENEUROPA-1730: Remove default value on publication field.

### DIFF
--- a/modules/oe_content_news/config/install/field.field.node.oe_news.oe_news_publication_date.yml
+++ b/modules/oe_content_news/config/install/field.field.node.oe_news.oe_news_publication_date.yml
@@ -10,11 +10,9 @@ entity_type: node
 bundle: oe_news
 label: 'Publication date'
 description: ''
-required: true
+required: false
 translatable: false
 default_value:
-  -
-    value: 1550753312
 default_value_callback: ''
 settings: {  }
 field_type: timestamp

--- a/tests/features/news.feature
+++ b/tests/features/news.feature
@@ -19,6 +19,7 @@ Feature: News content creation
     And I fill in "Body" with "Body text"
     And I fill in "Location" with "Budapest"
     And I fill in "Publication date" with the date "2019-02-21"
+    And I fill in "Publication date" with the time "16:59:00"
     And I fill in "Subject" with "financing"
     And I fill in "Author" with "European Patent Office"
     # Reference the media photo to the news item.


### PR DESCRIPTION
## OPENEUROPA-1730

### Description

Remove the default value on the publication date field and remove the required condition so it uses the current date.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed: Default value from publication date.
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

