### PR TITLE
OPENEUROPA-1709: Replace eurovoc with digital europa thesaurus.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,7 @@ services:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
   sparql:
     image: openeuropa/triple-store-dev
+    pull: true
     environment:
      - SPARQL_UPDATE=true
      - DBA_PASSWORD=dba

--- a/modules/oe_content_news/config/install/field.field.node.oe_news.oe_news_subject.yml
+++ b/modules/oe_content_news/config/install/field.field.node.oe_news.oe_news_subject.yml
@@ -24,11 +24,11 @@ settings:
       field: _none
     auto_create: 0
     concept_schemes:
-      - 'http://eurovoc.europa.eu/100141'
+      - 'http://data.europa.eu/uxp'
     field:
       field_name: oe_news_subject
       entity_type: node
       bundle: oe_news
       concept_schemes:
-        - 'http://eurovoc.europa.eu/100141'
+        - 'http://data.europa.eu/uxp'
 field_type: skos_concept_entity_reference

--- a/modules/oe_content_page/config/install/field.field.node.oe_page.oe_page_subject.yml
+++ b/modules/oe_content_page/config/install/field.field.node.oe_page.oe_page_subject.yml
@@ -24,11 +24,11 @@ settings:
       field: _none
     auto_create: 0
     concept_schemes:
-      - 'http://eurovoc.europa.eu/100141'
+      - 'http://data.europa.eu/uxp'
     field:
       field_name: oe_page_subject
       entity_type: node
       bundle: oe_page
       concept_schemes:
-        - 'http://eurovoc.europa.eu/100141'
+        - 'http://data.europa.eu/uxp'
 field_type: skos_concept_entity_reference

--- a/src/PublicationsOfficeSkosGraphSetup.php
+++ b/src/PublicationsOfficeSkosGraphSetup.php
@@ -43,6 +43,7 @@ class PublicationsOfficeSkosGraphSetup {
       'place' => 'http://publications.europa.eu/resource/dataset/place',
       'public_event_type' => 'http://publications.europa.eu/resource/dataset/public-event-type',
       'eurovoc' => 'http://publications.europa.eu/resource/dataset/eurovoc',
+      'europa_digital_thesaurus' => 'http://data.europa.eu/uxp',
     ];
   }
 


### PR DESCRIPTION
## OPENEUROPA-1709

### Description

Replace eurovoc on oe_content fields.

### Change log

- Added:
- Changed: Replace eurovoc on oe_content fields.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

