### PR TITLE
OPENEUROPA-1724: Make publication date a datetime field.

### DIFF
--- a/modules/oe_content_news/config/install/core.entity_form_display.node.oe_news.default.yml
+++ b/modules/oe_content_news/config/install/core.entity_form_display.node.oe_news.default.yml
@@ -30,7 +30,7 @@ content:
     third_party_settings: {  }
     region: content
   created:
-    type: datetime_timestamp
+    type: datetime_default
     weight: 14
     region: content
     settings: {  }

--- a/modules/oe_content_news/config/install/core.entity_form_display.node.oe_news.default.yml
+++ b/modules/oe_content_news/config/install/core.entity_form_display.node.oe_news.default.yml
@@ -30,7 +30,7 @@ content:
     third_party_settings: {  }
     region: content
   created:
-    type: datetime_default
+    type: datetime_timestamp
     weight: 14
     region: content
     settings: {  }
@@ -99,7 +99,7 @@ content:
     weight: 5
     settings: {  }
     third_party_settings: {  }
-    type: datetime_timestamp
+    type: datetime_default
     region: content
   oe_news_subject:
     weight: 6

--- a/modules/oe_content_news/config/install/field.field.node.oe_news.oe_news_publication_date.yml
+++ b/modules/oe_content_news/config/install/field.field.node.oe_news.oe_news_publication_date.yml
@@ -4,6 +4,8 @@ dependencies:
   config:
     - field.storage.node.oe_news_publication_date
     - node.type.oe_news
+  module:
+    - datetime
 id: node.oe_news.oe_news_publication_date
 field_name: oe_news_publication_date
 entity_type: node
@@ -13,6 +15,9 @@ description: ''
 required: false
 translatable: false
 default_value:
+  -
+    default_date_type: now
+    default_date: now
 default_value_callback: ''
 settings: {  }
-field_type: timestamp
+field_type: datetime

--- a/modules/oe_content_news/config/install/field.storage.node.oe_news_publication_date.yml
+++ b/modules/oe_content_news/config/install/field.storage.node.oe_news_publication_date.yml
@@ -2,13 +2,15 @@ langcode: en
 status: true
 dependencies:
   module:
+    - datetime
     - node
 id: node.oe_news_publication_date
 field_name: oe_news_publication_date
 entity_type: node
-type: timestamp
-settings: {  }
-module: core
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
 locked: false
 cardinality: 1
 translatable: true

--- a/modules/oe_content_news/oe_content_news.info.yml
+++ b/modules/oe_content_news/oe_content_news.info.yml
@@ -9,6 +9,7 @@ dependencies:
   - oe_media:oe_media
   - oe_media_avportal:oe_media_avportal
   - maxlength:maxlength
+  - drupal:datetime
 
 config_devel:
   - core.entity_form_display.node.oe_news.default

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -52,7 +52,7 @@ class FeatureContext extends RawDrupalContext {
    *   Thrown when the field was not found.
    */
   public function findDateFields($field) {
-    $field_selectors = $this->getSession()->getPage()->findAll('css', '.field--widget-datetime-timestamp');
+    $field_selectors = $this->getSession()->getPage()->findAll('css', '.field--widget-datetime-default');
     $field_selectors = array_filter($field_selectors, function ($field_selector) use ($field) {
       return $field_selector->has('named', ['content', $field]);
     });

--- a/tests/features/news.feature
+++ b/tests/features/news.feature
@@ -19,7 +19,6 @@ Feature: News content creation
     And I fill in "Body" with "Body text"
     And I fill in "Location" with "Budapest"
     And I fill in "Publication date" with the date "2019-02-21"
-    And I fill in "Publication date" with the time "16:59:00"
     And I fill in "Subject" with "financing"
     And I fill in "Author" with "European Patent Office"
     # Reference the media photo to the news item.


### PR DESCRIPTION
## OPENEUROPA-1724

### Description

Make publication date field a datetime field.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

