### PR TITLE
OPENEUROPA-1852: Default and optional content language settings for the content types.

### DIFF
--- a/modules/oe_content_news/config/optional/language.content_settings.node.oe_news.yml
+++ b/modules/oe_content_news/config/optional/language.content_settings.node.oe_news.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.oe_news
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: node.oe_news
+target_entity_type_id: node
+target_bundle: oe_news
+default_langcode: site_default
+language_alterable: true

--- a/modules/oe_content_page/config/optional/language.content_settings.node.oe_page.yml
+++ b/modules/oe_content_page/config/optional/language.content_settings.node.oe_page.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.oe_page
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: node.oe_page
+target_entity_type_id: node
+target_bundle: oe_page
+default_langcode: site_default
+language_alterable: true


### PR DESCRIPTION
Similar to how [OE Paragraphs](https://github.com/openeuropa/oe_paragraphs/blob/master/config/optional/language.content_settings.paragraph.oe_list_item.yml) provides language settings for the paragraph types, we need to provide our own for the content types.
