### PR TITLE
OPENEUROPA-1856: Add missing config_devel entries.

### DIFF
--- a/modules/oe_content_page/oe_content_page.info.yml
+++ b/modules/oe_content_page/oe_content_page.info.yml
@@ -18,3 +18,5 @@ config_devel:
     - field.field.node.oe_page.oe_summary
     - field.field.node.oe_page.oe_teaser
     - node.type.oe_page
+  optional:
+    - language.content_settings.node.oe_page

--- a/modules/oe_content_persistent/oe_content_persistent.info.yml
+++ b/modules/oe_content_persistent/oe_content_persistent.info.yml
@@ -9,3 +9,7 @@ configure: oe_content_persistent.purl_settings
 
 dependencies:
   - linkit:linkit
+
+config_devel:
+  install:
+    - oe_content_persistent.settings

--- a/oe_content.info.yml
+++ b/oe_content.info.yml
@@ -13,4 +13,9 @@ dependencies:
 
 config_devel:
   install:
+    - field.storage.node.oe_author
+    - field.storage.node.oe_publication_date
     - field.storage.node.oe_related_links
+    - field.storage.node.oe_subject
+    - field.storage.node.oe_summary
+    - field.storage.node.oe_teaser


### PR DESCRIPTION
## OPENEUROPA-1856
### Description

Add missing config_devel entries

### Change log

- Added: Add missing config_devel entries
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

