### PR TITLE
Update documentation for openeuropa platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Otherwise, ensure that in your site's `setting.php` file you have the connection
 ```
 $databases["sparql_default"] = array(
   'default' => array(
-    'prefix' => '', 
+    'prefix' => '',
     'host' => 'your-triple-store-host',
     'port' => '8890',
     'namespace' => 'Drupal\\Driver\\Database\\sparql',
@@ -77,6 +77,24 @@ $databases["sparql_default"] = array(
   )
 );
 ```
+
+#### OpenEuropa site template setup
+
+If you are working on a project using the OpenEuropa site template you should add the following to the runner.yml.dist file:
+
+```
+drupal:
+  additional_settings: |
+    $databases['sparql_default']['default'] = [
+      'prefix' => '',
+      'host' => getenv('DRUPAL_SPARQL_HOSTNAME'),
+      'port' => getenv('DRUPAL_SPARQL_PORT'),
+      'namespace' => 'Drupal\\Driver\\Database\\sparql',
+      'driver' => 'sparql',
+    ];
+```
+
+This ensures that the config is in place before the installation and by doing so you no longer have to modify the settings.php manually.
 
 ## Usage
 
@@ -122,10 +140,10 @@ Your test site will be available at `./build`.
 
 ### Using Docker Compose
 
-Alternatively, you can build a development site using [Docker](https://www.docker.com/get-docker) and 
+Alternatively, you can build a development site using [Docker](https://www.docker.com/get-docker) and
 [Docker Compose](https://docs.docker.com/compose/) with the provided configuration.
 
-Docker provides the necessary services and tools such as a web server and a database server to get the site running, 
+Docker provides the necessary services and tools such as a web server and a database server to get the site running,
 regardless of your local host configuration.
 
 #### Requirements:
@@ -137,7 +155,7 @@ regardless of your local host configuration.
 
 By default, Docker Compose reads two files, a `docker-compose.yml` and an optional `docker-compose.override.yml` file.
 By convention, the `docker-compose.yml` contains your base configuration and it's provided by default.
-The override file, as its name implies, can contain configuration overrides for existing services or entirely new 
+The override file, as its name implies, can contain configuration overrides for existing services or entirely new
 services.
 If a service is defined in both files, Docker Compose merges the configurations.
 


### PR DESCRIPTION
This adds a little documentation snippet on how to configure the settings.php on sites based on the site template.