### PR TITLE
MULTISITE-21706: Update field_group to ^3.0@rc and rdf_skos to ~0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
     "prefer-stable": true,
     "require": {
         "drupal/core": "^8.7",
-        "drupal/field_group": "^1.0",
+        "drupal/field_group": "^3.0@rc",
         "drupal/linkit": "~5.0-beta8",
         "drupal/maxlength": "~1.0@beta",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",
-        "openeuropa/rdf_skos": "~0.3",
+        "openeuropa/rdf_skos": "~0.4",
         "openeuropa/oe_media": "^1.0@beta",
         "php": "^7.1"
     },


### PR DESCRIPTION
From the project page: https://www.drupal.org/project/field_group

> For Drupal 8.3 and higher, use the fieldgroup 8.3 branch. When you still use a drupal version lower then 8.3, use the fieldgroup 8.1 branch

Same should happen for openeuropa/rdf_skos which is a requirement of openeuropa/oe_content. So that dependency should go onto ~0.4 with its release of 0.4.0.
