### PR TITLE
OPENEUROPA-2188: Fix failing tests.

### DIFF
--- a/modules/oe_content_persistent/tests/src/Functional/PersistentUrlControllerTest.php
+++ b/modules/oe_content_persistent/tests/src/Functional/PersistentUrlControllerTest.php
@@ -38,6 +38,9 @@ class PersistentUrlControllerTest extends BrowserTestBase {
 
     $node_type = NodeType::create(['type' => 'page']);
     $node_type->save();
+
+    $user = $this->drupalCreateUser(['access content']);
+    $this->drupalLogin($user);
   }
 
   /**


### PR DESCRIPTION
## OPENEUROPA-2188

### Description

Builds are failing on the oe_content_persistent module.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed: Fix failing test.
- Security:

### Commands

```sh
[Insert commands here]

```

