### PR TITLE
OPENEUROPA-2259: Fix behat/mink-selenium2-driver missing branch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,14 @@
         "openeuropa/task-runner": "~1.0@beta",
         "phpunit/phpunit": "~6.0",
         "symfony/dom-crawler": "~3.0",
-        "drupaltest/behat-traits": "dev-8.x-1.x"
+        "drupaltest/behat-traits": "dev-8.x-1.x",
+        "behat/mink-selenium2-driver": "dev-master#8684ee4 as 1.3.x-dev",
+        "behat/mink": "dev-master#a534fe7"
     },
+    "_readme": [
+        "We need to alias a specific version of 'behat/mink-selenium2-driver' to '1.3.x-dev' since this branch is not available any longer. For more information check: https://github.com/minkphp/MinkSelenium2Driver/issues/313.",
+        "Upcoming ~1.4 of 'behat/mink-selenium2-driver' is known to have issues with latest 'behat/mink', so we need to pinpoint a specific version of the latter. For more information check: https://www.drupal.org/project/drupal/issues/3078671#comment-13244409."
+    ],
     "autoload": {
         "psr-4": {
             "Drupal\\oe_content\\": "./src/"

--- a/modules/oe_content_persistent/tests/src/Functional/PersistentUrlControllerTest.php
+++ b/modules/oe_content_persistent/tests/src/Functional/PersistentUrlControllerTest.php
@@ -38,6 +38,9 @@ class PersistentUrlControllerTest extends BrowserTestBase {
 
     $node_type = NodeType::create(['type' => 'page']);
     $node_type->save();
+
+    $user = $this->drupalCreateUser(['access content']);
+    $this->drupalLogin($user);
   }
 
   /**


### PR DESCRIPTION
## OPENEUROPA-2259

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

