### PR TITLE
OPENEUROPA-2262: Remove name mappings on image and document media types.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,14 +28,8 @@
         "openeuropa/task-runner": "~1.0@beta",
         "phpunit/phpunit": "~6.0",
         "symfony/dom-crawler": "~3.0",
-        "drupaltest/behat-traits": "dev-8.x-1.x",
-        "behat/mink-selenium2-driver": "dev-master#8684ee4 as 1.3.x-dev",
-        "behat/mink": "dev-master#a534fe7"
+        "drupaltest/behat-traits": "dev-8.x-1.x"
     },
-    "_readme": [
-        "We need to alias a specific version of 'behat/mink-selenium2-driver' to '1.3.x-dev' since this branch is not available any longer. For more information check: https://github.com/minkphp/MinkSelenium2Driver/issues/313.",
-        "Upcoming ~1.4 of 'behat/mink-selenium2-driver' is known to have issues with latest 'behat/mink', so we need to pinpoint a specific version of the latter. For more information check: https://www.drupal.org/project/drupal/issues/3078671#comment-13244409."
-    ],
     "autoload": {
         "psr-4": {
             "Drupal\\oe_content\\": "./src/"

--- a/oe_content.post_update.php
+++ b/oe_content.post_update.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for OpenEuropa Content module.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\media\Entity\MediaType;
+
+/**
+ * Remove the mapping of name to title on documents and image media types.
+ */
+function oe_content_post_update_00001(): void {
+  $media_types = ['document', 'image'];
+  foreach ($media_types as $media_type_id) {
+    /** @var \Drupal\media\Entity\MediaType $media_type */
+    $media_type = MediaType::load($media_type_id);
+    $field_mappings = $media_type->get('field_map');
+    if (isset($field_mappings['name']) && $field_mappings['name'] == 'name') {
+      unset($field_mappings['name']);
+    }
+    $media_type->set('field_map', $field_mappings);
+    $media_type->save();
+  }
+}


### PR DESCRIPTION
## OPENEUROPA-2262

### Description

Given an existing media image, if a user edits it and changes one of the values of the source field (alternative text in this case) the image will get its title replaced with the file name.

We need to go through all the media types we created and remove any field mapping that is actually not provided from the source OR that we don't want provided from the source

### Change log

- Added:
- Changed: Remove name mappings on image and document media types.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

