### PR TITLE
OPENEUROPA-2224: Add support of Country corporate vocabulary.

### DIFF
--- a/oe_content.post_update.php
+++ b/oe_content.post_update.php
@@ -54,5 +54,20 @@ function oe_content_post_update_00001(): void {
  * Add Country corporate vocabulary.
  */
 function oe_content_post_update_00002(): void {
-  \Drupal::service('oe_content.op_skos_setup')->setup();
+  $config = \Drupal::configFactory()->getEditable('rdf_skos.graphs');
+
+  $entity_types = $config->get('entity_types');
+
+  $name = 'country';
+  $graph = 'http://publications.europa.eu/resource/authority/country';
+  $entity_types['skos_concept_scheme'][] = [
+    'name' => $name,
+    'uri' => $graph,
+  ];
+  $entity_types['skos_concept'][] = [
+    'name' => $name,
+    'uri' => $graph,
+  ];
+
+  $config->set('entity_types', $entity_types)->save();
 }

--- a/oe_content.post_update.php
+++ b/oe_content.post_update.php
@@ -49,3 +49,10 @@ function oe_content_post_update_00001(): void {
     }
   }
 }
+
+/**
+ * Add Country corporate vocabulary.
+ */
+function oe_content_post_update_00002(): void {
+  \Drupal::service('oe_content.op_skos_setup')->setup();
+}

--- a/src/PublicationsOfficeSkosGraphSetup.php
+++ b/src/PublicationsOfficeSkosGraphSetup.php
@@ -44,6 +44,7 @@ class PublicationsOfficeSkosGraphSetup {
       'public_event_type' => 'http://publications.europa.eu/resource/dataset/public-event-type',
       'eurovoc' => 'http://publications.europa.eu/resource/dataset/eurovoc',
       'europa_digital_thesaurus' => 'http://data.europa.eu/uxp',
+      'country' => 'http://publications.europa.eu/resource/authority/country',
     ];
   }
 


### PR DESCRIPTION
## OPENEUROPA-2224

### Description

Create the country corporate vocabulary in rdf skos. 

Ensure it gets added to the remote triple store self-update thing.

See attachment for the values.
### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

