### PR TITLE
OPENEUROPA-2318: Resort to 404 pages if no entity is found for a uuid on the persistent text filter.

### DIFF
--- a/modules/oe_content_persistent/tests/src/Kernel/PersistentUrlFilterTest.php
+++ b/modules/oe_content_persistent/tests/src/Kernel/PersistentUrlFilterTest.php
@@ -127,6 +127,22 @@ class PersistentUrlFilterTest extends KernelTestBase {
     $expected = '<a href="/alias2">test</a>';
     $output = $test($input, 'en');
     $this->assertSame($expected, $output->getProcessedText());
+
+    $uuid_service = \Drupal::service('uuid');
+    $uuid = $uuid_service->generate();
+
+    $input = '<a href="' . $base_url . $uuid . '">test</a>';
+    $expected = '<a href="/system/404">test</a>';
+    $output = $test($input, 'fr');
+    $this->assertSame($expected, $output->getProcessedText());
+
+    $system_config = \Drupal::configFactory()->getEditable('system.site');
+    $system_config->set('page.404', '/custom/404');
+    $system_config->save();
+
+    $expected = '<a href="/custom/404">test</a>';
+    $output = $test($input, 'fr');
+    $this->assertSame($expected, $output->getProcessedText());
   }
 
 }


### PR DESCRIPTION
## OPENEUROPA-2318

### Description

The persistent url keeps the purl target as it is if it doesn't find the target uuid entity. If no entity is found we revert to a 404 page.

### Change log

- Added:
- Changed: The persistent url keeps the purl target as it is if it doesn't find the target uuid entity. If no entity is found we revert to a 404 page.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

