### PR TITLE
OPENEUROPA-2487: Publication date field should not be translatable.

### DIFF
--- a/modules/oe_content_publication/config/install/field.field.node.oe_publication.oe_publication_date.yml
+++ b/modules/oe_content_publication/config/install/field.field.node.oe_publication.oe_publication_date.yml
@@ -13,7 +13,7 @@ bundle: oe_publication
 label: 'Publication date'
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value:
   -
     default_date_type: now


### PR DESCRIPTION
No upgrade path needed here because we don't want to force users of the component to automatically change their field config. They have the option to run their own upgrade path if they want.