### PR TITLE
OPENEUROPA-2488: TMGMT field preprocessor for the Timeline field.

### DIFF
--- a/modules/oe_content_timeline_field/oe_content_timeline_field.module
+++ b/modules/oe_content_timeline_field/oe_content_timeline_field.module
@@ -28,3 +28,14 @@ function oe_content_timeline_field_theme() {
 function oe_content_timeline_field_locale_translation_projects_alter(&$projects) {
   $projects['oe_content_timeline_field']['info']['interface translation server pattern'] = drupal_get_path('module', 'oe_content_timeline_field') . '/translations/%project-%language.po';
 }
+
+/**
+ * Implements hook_field_info_alter().
+ */
+function oe_content_timeline_field_field_info_alter(&$info) {
+  if (isset($info['timeline_field'])) {
+    // For the timeline_field field we need to use our own processor. This is
+    // only used if TMGMT is installed.
+    $info['timeline_field']['tmgmt_field_processor'] = 'Drupal\oe_content_timeline_field\TmgmtTimelineFieldProcessor';
+  }
+}

--- a/modules/oe_content_timeline_field/src/TmgmtTimelineFieldProcessor.php
+++ b/modules/oe_content_timeline_field/src/TmgmtTimelineFieldProcessor.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_content_timeline_field;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\tmgmt_content\DefaultFieldProcessor;
+
+/**
+ * TMGMT field processor for the timeline field.
+ */
+class TmgmtTimelineFieldProcessor extends DefaultFieldProcessor {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function extractTranslatableData(FieldItemListInterface $field) {
+    $data = parent::extractTranslatableData($field);
+
+    // Remove the #format from the columns which actually should not have a
+    // text format.
+    foreach ($data as $delta => &$value) {
+      if (!is_numeric($delta)) {
+        continue;
+      }
+
+      foreach (['label', 'title'] as $name) {
+        if (isset($value[$name]['#format'])) {
+          unset($value[$name]['#format']);
+        }
+      }
+    }
+
+    return $data;
+  }
+
+}


### PR DESCRIPTION
When testing this:

* Install the component and make sure stuff doesn't break with the TMGMT module missing.
* Install it in EWCMS where we have local translation and ensure that translating a timeline field, the title doesn't get HTML tags in. 

