### PR TITLE
OPENEUROPA-2584: Keep query parameters and fragments from PURL.

### DIFF
--- a/modules/oe_content_persistent/src/Plugin/Filter/FilterPurl.php
+++ b/modules/oe_content_persistent/src/Plugin/Filter/FilterPurl.php
@@ -8,6 +8,7 @@ use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Component\Uuid\Uuid;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
 use Drupal\filter\FilterProcessResult;
@@ -116,18 +117,18 @@ class FilterPurl extends FilterBase implements ContainerFactoryPluginInterface {
         // we link to the 404 page of the site so that it mirrors the default
         // effect of the referenced entity being deleted from the system.
         $entity = $this->contentUuidResolver->getEntityByUuid($uuid, $langcode);
-        $url = $entity ? $entity->toUrl('canonical', [
-          'query' => $parsed_href['query'],
-          'fragment' => $parsed_href['fragment'],
-        ])->toString(TRUE) : $this->getDefaultPageNotFoundUrl()->toString(TRUE);
-        $node->setAttribute('href', $url->getGeneratedUrl());
-
-        if ($entity) {
+        if ($entity instanceof EntityInterface) {
+          $url = $entity->toUrl('canonical', [
+            'query' => $parsed_href['query'],
+            'fragment' => $parsed_href['fragment'],
+          ])->toString(TRUE);
           $result->addCacheableDependency($entity);
         }
         else {
+          $url = $this->getDefaultPageNotFoundUrl()->toString(TRUE);
           $result->addCacheableDependency($this->siteConfig);
         }
+        $node->setAttribute('href', $url->getGeneratedUrl());
 
         $result->addCacheableDependency($url);
       }

--- a/modules/oe_content_persistent/src/Plugin/Filter/FilterPurl.php
+++ b/modules/oe_content_persistent/src/Plugin/Filter/FilterPurl.php
@@ -8,7 +8,7 @@ use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Component\Uuid\Uuid;
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
 use Drupal\filter\FilterProcessResult;
@@ -111,13 +111,12 @@ class FilterPurl extends FilterBase implements ContainerFactoryPluginInterface {
           continue;
         }
 
-        $parsed_href = UrlHelper::parse($href);
-
         // We try to load the entity based on the UUID. If we fail, however,
         // we link to the 404 page of the site so that it mirrors the default
         // effect of the referenced entity being deleted from the system.
         $entity = $this->contentUuidResolver->getEntityByUuid($uuid, $langcode);
-        if ($entity instanceof EntityInterface) {
+        if ($entity instanceof ContentEntityInterface) {
+          $parsed_href = UrlHelper::parse($href);
           $url = $entity->toUrl('canonical', [
             'query' => $parsed_href['query'],
             'fragment' => $parsed_href['fragment'],

--- a/modules/oe_content_persistent/src/Plugin/Filter/FilterPurl.php
+++ b/modules/oe_content_persistent/src/Plugin/Filter/FilterPurl.php
@@ -109,11 +109,21 @@ class FilterPurl extends FilterBase implements ContainerFactoryPluginInterface {
           continue;
         }
 
+        // If an anchor is set on the source url, we extract it here.
+        $anchor = '';
+        if (strpos($href, '#') !== FALSE) {
+          $explodedHref = explode('#', $href);
+          if (isset($explodedHref[1]) && !empty($explodedHref[1])) {
+            $anchor = '#' . $explodedHref[1];
+          }
+        }
+
         // We try to load the entity based on the UUID. If we fail, however,
         // we link to the 404 page of the site so that it mirrors the default
         // effect of the referenced entity being deleted from the system.
         $entity = $this->contentUuidResolver->getEntityByUuid($uuid, $langcode);
         $url = $entity ? $entity->toUrl()->toString(TRUE) : $this->getDefaultPageNotFoundUrl()->toString(TRUE);
+        $url = $url->setGeneratedUrl($url->getGeneratedUrl() . $anchor);
         $node->setAttribute('href', $url->getGeneratedUrl());
 
         if ($entity) {

--- a/modules/oe_content_persistent/tests/src/Kernel/PersistentUrlFilterTest.php
+++ b/modules/oe_content_persistent/tests/src/Kernel/PersistentUrlFilterTest.php
@@ -143,6 +143,24 @@ class PersistentUrlFilterTest extends KernelTestBase {
     $expected = '<a href="/custom/404">test</a>';
     $output = $test($input, 'fr');
     $this->assertSame($expected, $output->getProcessedText());
+
+    // Make sure that we don't loose query parameters and fragments.
+    $input = '<a href="' . $base_url . $node->uuid() . '?param1=value1&param2=value2#hashexampl">test</a>';
+    $expected = '<a href="/alias2?param1=value1&amp;param2=value2#hashexampl">test</a>';
+    $output = $test($input, 'en');
+    $this->assertSame($expected, $output->getProcessedText());
+
+    // Make sure that we don't loose query parameters.
+    $input = '<a href="' . $base_url . $node->uuid() . '?param1=value1&param2=value2">test</a>';
+    $expected = '<a href="/alias2?param1=value1&amp;param2=value2">test</a>';
+    $output = $test($input, 'en');
+    $this->assertSame($expected, $output->getProcessedText());
+
+    // Make sure that we don't loose fragments.
+    $input = '<a href="' . $base_url . $node->uuid() . '#hashexampl">test</a>';
+    $expected = '<a href="/alias2#hashexampl">test</a>';
+    $output = $test($input, 'en');
+    $this->assertSame($expected, $output->getProcessedText());
   }
 
 }


### PR DESCRIPTION
## OPENEUROPA-2584

### Description

In the persistent url logic we rebuild urls without anchors. Rob contributed a PR to take care of this problem. We should complete the solution with doing the same with query parameters.

https://github.com/openeuropa/oe_content/pull/136

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

