### PR TITLE
OPENEUROPA-2801: Set subject field optional for Page content type.

### DIFF
--- a/modules/oe_content_page/config/install/field.field.node.oe_page.oe_subject.yml
+++ b/modules/oe_content_page/config/install/field.field.node.oe_page.oe_subject.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: oe_page
 label: Subject
 description: 'The topics mentioned on this page. These will be used by search engines and dynamic lists to determine their relevance to a user.'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
## OPENEUROPA-2801

### Description

Set subject field optional for Page content type.

### Change log

- Added:
- Changed: required status of subject field in Page
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh

```

