### PR TITLE
OPENEUROPA-2771: Add optional social media field to General and Press bundles of Contact entity.

### DIFF
--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_form_display.oe_contact.oe_general.default.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_form_display.oe_contact.oe_general.default.yml
@@ -5,9 +5,11 @@ dependencies:
     - field.field.oe_contact.oe_general.oe_address
     - field.field.oe_contact.oe_general.oe_email
     - field.field.oe_contact.oe_general.oe_phone
+    - field.field.oe_contact.oe_general.oe_social_media
     - oe_content_entity_contact.oe_contact_type.oe_general
   module:
     - address
+    - typed_link
 id: oe_contact.oe_general.default
 targetEntityType: oe_contact
 bundle: oe_general
@@ -35,6 +37,14 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  oe_social_media:
+    type: typed_link
+    weight: 5
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 0

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_form_display.oe_contact.oe_press.default.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_form_display.oe_contact.oe_press.default.yml
@@ -5,9 +5,11 @@ dependencies:
     - field.field.oe_contact.oe_press.oe_address
     - field.field.oe_contact.oe_press.oe_email
     - field.field.oe_contact.oe_press.oe_phone
+    - field.field.oe_contact.oe_press.oe_social_media
     - oe_content_entity_contact.oe_contact_type.oe_press
   module:
     - address
+    - typed_link
 id: oe_contact.oe_press.default
 targetEntityType: oe_contact
 bundle: oe_press
@@ -35,6 +37,14 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  oe_social_media:
+    type: typed_link
+    weight: 5
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 0

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_view_display.oe_contact.oe_general.default.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_view_display.oe_contact.oe_general.default.yml
@@ -5,9 +5,11 @@ dependencies:
     - field.field.oe_contact.oe_general.oe_address
     - field.field.oe_contact.oe_general.oe_email
     - field.field.oe_contact.oe_general.oe_phone
+    - field.field.oe_contact.oe_general.oe_social_media
     - oe_content_entity_contact.oe_contact_type.oe_general
   module:
     - address
+    - typed_link
 id: oe_contact.oe_general.default
 targetEntityType: oe_contact
 bundle: oe_general
@@ -35,5 +37,17 @@ content:
     third_party_settings: {  }
     type: string
     region: content
+  oe_social_media:
+    type: typed_link
+    weight: 4
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
 hidden:
   langcode: true

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_view_display.oe_contact.oe_press.default.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_view_display.oe_contact.oe_press.default.yml
@@ -5,9 +5,11 @@ dependencies:
     - field.field.oe_contact.oe_press.oe_address
     - field.field.oe_contact.oe_press.oe_email
     - field.field.oe_contact.oe_press.oe_phone
+    - field.field.oe_contact.oe_press.oe_social_media
     - oe_content_entity_contact.oe_contact_type.oe_press
   module:
     - address
+    - typed_link
 id: oe_contact.oe_press.default
 targetEntityType: oe_contact
 bundle: oe_press
@@ -35,5 +37,17 @@ content:
     third_party_settings: {  }
     type: string
     region: content
+  oe_social_media:
+    type: typed_link
+    weight: 4
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
 hidden:
   langcode: true

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.field.oe_contact.oe_general.oe_social_media.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.field.oe_contact.oe_general.oe_social_media.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.oe_contact.oe_social_media
+    - oe_content_entity_contact.oe_contact_type.oe_general
+  module:
+    - typed_link
+id: oe_contact.oe_general.oe_social_media
+field_name: oe_social_media
+entity_type: oe_contact
+bundle: oe_general
+label: 'Social media links'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: typed_link

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.field.oe_contact.oe_press.oe_social_media.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.field.oe_contact.oe_press.oe_social_media.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.oe_contact.oe_social_media
+    - oe_content_entity_contact.oe_contact_type.oe_press
+  module:
+    - typed_link
+id: oe_contact.oe_press.oe_social_media
+field_name: oe_social_media
+entity_type: oe_contact
+bundle: oe_press
+label: 'Social media links'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: typed_link

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.storage.oe_contact.oe_social_media.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.storage.oe_contact.oe_social_media.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - oe_content_entity_contact
+    - typed_link
+id: oe_contact.oe_social_media
+field_name: oe_social_media
+entity_type: oe_contact
+type: typed_link
+settings:
+  allowed_values:
+    email: Email
+    facebook: Facebook
+    flickr: Flickr
+    google: Google+
+    instagram: Instagram
+    linkedin: Linkedin
+    pinterest: Pinterest
+    rss: RSS
+    storify: Storify
+    twitter: Twitter
+    yammer: Yammer
+    youtube: YouTube
+  allowed_values_function: ''
+module: typed_link
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## OPENEUROPA-2771

### Description

Add optional social media field to General and Press bundles of Contact entity.

### Change log

- Added: social media field to general and press bundles
- Changed: general and press form and view displays
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh

```

