### PR TITLE
OPENEUROPA-2771: Add social media links field to Press and General bundles.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -56,6 +56,7 @@ default:
         Description: "#edit-oe-event-featured-media"
         Event report: "#edit-group-report"
         Event contact: "#edit-oe-event-contact-wrapper"
+        Event contact social media links: ".field--name-oe-social-media"
       selectors:
         message_selector: '.messages'
         error_message_selector: '.messages.messages--error'

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_form_display.oe_contact.oe_general.default.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_form_display.oe_contact.oe_general.default.yml
@@ -5,9 +5,11 @@ dependencies:
     - field.field.oe_contact.oe_general.oe_address
     - field.field.oe_contact.oe_general.oe_email
     - field.field.oe_contact.oe_general.oe_phone
+    - field.field.oe_contact.oe_general.oe_social_media
     - oe_content_entity_contact.oe_contact_type.oe_general
   module:
     - address
+    - typed_link
 id: oe_contact.oe_general.default
 targetEntityType: oe_contact
 bundle: oe_general
@@ -35,6 +37,14 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  oe_social_media:
+    type: typed_link
+    weight: 5
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 0

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_form_display.oe_contact.oe_press.default.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_form_display.oe_contact.oe_press.default.yml
@@ -5,9 +5,11 @@ dependencies:
     - field.field.oe_contact.oe_press.oe_address
     - field.field.oe_contact.oe_press.oe_email
     - field.field.oe_contact.oe_press.oe_phone
+    - field.field.oe_contact.oe_press.oe_social_media
     - oe_content_entity_contact.oe_contact_type.oe_press
   module:
     - address
+    - typed_link
 id: oe_contact.oe_press.default
 targetEntityType: oe_contact
 bundle: oe_press
@@ -35,6 +37,14 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  oe_social_media:
+    type: typed_link
+    weight: 5
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 0

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_view_display.oe_contact.oe_general.default.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_view_display.oe_contact.oe_general.default.yml
@@ -5,9 +5,11 @@ dependencies:
     - field.field.oe_contact.oe_general.oe_address
     - field.field.oe_contact.oe_general.oe_email
     - field.field.oe_contact.oe_general.oe_phone
+    - field.field.oe_contact.oe_general.oe_social_media
     - oe_content_entity_contact.oe_contact_type.oe_general
   module:
     - address
+    - typed_link
 id: oe_contact.oe_general.default
 targetEntityType: oe_contact
 bundle: oe_general
@@ -35,5 +37,17 @@ content:
     third_party_settings: {  }
     type: string
     region: content
+  oe_social_media:
+    type: typed_link
+    weight: 4
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
 hidden:
   langcode: true

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_view_display.oe_contact.oe_press.default.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/core.entity_view_display.oe_contact.oe_press.default.yml
@@ -5,9 +5,11 @@ dependencies:
     - field.field.oe_contact.oe_press.oe_address
     - field.field.oe_contact.oe_press.oe_email
     - field.field.oe_contact.oe_press.oe_phone
+    - field.field.oe_contact.oe_press.oe_social_media
     - oe_content_entity_contact.oe_contact_type.oe_press
   module:
     - address
+    - typed_link
 id: oe_contact.oe_press.default
 targetEntityType: oe_contact
 bundle: oe_press
@@ -35,5 +37,17 @@ content:
     third_party_settings: {  }
     type: string
     region: content
+  oe_social_media:
+    type: typed_link
+    weight: 4
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
 hidden:
   langcode: true

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.field.oe_contact.oe_general.oe_social_media.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.field.oe_contact.oe_general.oe_social_media.yml
@@ -16,5 +16,7 @@ required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  link_type: 16
+  title: 1
 field_type: typed_link

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.field.oe_contact.oe_general.oe_social_media.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.field.oe_contact.oe_general.oe_social_media.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.oe_contact.oe_social_media
+    - oe_content_entity_contact.oe_contact_type.oe_general
+  module:
+    - typed_link
+id: oe_contact.oe_general.oe_social_media
+field_name: oe_social_media
+entity_type: oe_contact
+bundle: oe_general
+label: 'Social media links'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: typed_link

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.field.oe_contact.oe_press.oe_social_media.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.field.oe_contact.oe_press.oe_social_media.yml
@@ -16,5 +16,7 @@ required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  link_type: 16
+  title: 1
 field_type: typed_link

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.field.oe_contact.oe_press.oe_social_media.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.field.oe_contact.oe_press.oe_social_media.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.oe_contact.oe_social_media
+    - oe_content_entity_contact.oe_contact_type.oe_press
+  module:
+    - typed_link
+id: oe_contact.oe_press.oe_social_media
+field_name: oe_social_media
+entity_type: oe_contact
+bundle: oe_press
+label: 'Social media links'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: typed_link

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.storage.oe_contact.oe_social_media.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/config/install/field.storage.oe_contact.oe_social_media.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - oe_content_entity_contact
+    - typed_link
+id: oe_contact.oe_social_media
+field_name: oe_social_media
+entity_type: oe_contact
+type: typed_link
+settings:
+  allowed_values:
+    email: Email
+    facebook: Facebook
+    flickr: Flickr
+    google: Google+
+    instagram: Instagram
+    linkedin: Linkedin
+    pinterest: Pinterest
+    rss: RSS
+    storify: Storify
+    twitter: Twitter
+    yammer: Yammer
+    youtube: YouTube
+  allowed_values_function: ''
+module: typed_link
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/oe_content_entity/modules/oe_content_entity_contact/oe_content_entity_contact.info.yml
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/oe_content_entity_contact.info.yml
@@ -7,6 +7,7 @@ core: 8.x
 dependencies:
   - oe_content:oe_content_entity
   - address:address
+  - typed_link:typed_link
 
 config_devel:
   install:
@@ -17,9 +18,11 @@ config_devel:
     - field.field.oe_contact.oe_general.oe_address
     - field.field.oe_contact.oe_general.oe_email
     - field.field.oe_contact.oe_general.oe_phone
+    - field.field.oe_contact.oe_general.oe_social_media
     - field.field.oe_contact.oe_press.oe_address
     - field.field.oe_contact.oe_press.oe_email
     - field.field.oe_contact.oe_press.oe_phone
+    - field.field.oe_contact.oe_press.oe_social_media
     - field.storage.oe_contact.oe_address
     - field.storage.oe_contact.oe_email
     - field.storage.oe_contact.oe_phone

--- a/tests/Behat/Content/Contact/GeneralContactContext.php
+++ b/tests/Behat/Content/Contact/GeneralContactContext.php
@@ -27,6 +27,7 @@ class GeneralContactContext extends RawDrupalContext {
       'Address' => 'oe_address',
       'Email' => 'oe_email',
       'Phone number' => 'oe_phone',
+      'Social media links' => 'oe_social_media',
     ];
 
     foreach ($scope->getFields() as $key => $value) {

--- a/tests/Behat/Content/Contact/PressContactContext.php
+++ b/tests/Behat/Content/Contact/PressContactContext.php
@@ -27,6 +27,7 @@ class PressContactContext extends RawDrupalContext {
       'Address' => 'oe_address',
       'Email' => 'oe_email',
       'Phone number' => 'oe_phone',
+      'Social media links' => 'oe_social_media',
     ];
 
     foreach ($scope->getFields() as $key => $value) {

--- a/tests/features/event.feature
+++ b/tests/features/event.feature
@@ -219,6 +219,8 @@ Feature: Event content creation
     And I fill in "City" with "Budapest" in the "Event contact" region
     And I fill in "Email" with "test@example.com" in the "Event contact" region
     And I fill in "Phone number" with "0488779033" in the "Event contact" region
+    And I fill in "URL" with "mailto:example@email.com" in the "Event contact social media links" region
+    And I fill in "Link text" with "Email" in the "Event contact social media links" region
 
     And I fill in "Content owner" with "Committee on Agriculture and Rural Development"
     And I fill in "Responsible department" with "Audit Board of the European Communities"
@@ -265,6 +267,7 @@ Feature: Event content creation
     And I should see the text "Hungary"
     And I should see the text "test@example.com"
     And I should see the text "0488779033"
+    And I should see the link "Email"
 
   @javascript @av_portal
   Scenario: As an editor when I create an Event node, the required fields are correctly marked when not filled in.


### PR DESCRIPTION
## OPENEUROPA-2771

### Description

Add social media links field to Press and General bundles.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

