### PR TITLE
OPENEUROPA-3135: Add composite entity reference field functionality.

### DIFF
--- a/config/schema/oe_content.schema.yml
+++ b/config/schema/oe_content.schema.yml
@@ -1,0 +1,7 @@
+field.field.*.*.*.third_party.oe_content:
+  type: mapping
+  label: 'Composite reference settings'
+  mapping:
+    composite:
+      type: boolean
+      label: 'Whether the field is a composite reference or not.'

--- a/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_contact.yml
+++ b/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_contact.yml
@@ -8,6 +8,10 @@ dependencies:
     - oe_content_entity_contact.oe_contact_type.oe_press
   module:
     - entity_reference_revisions
+    - oe_content
+third_party_settings:
+  oe_content:
+    composite: true
 id: node.oe_event.oe_event_contact
 field_name: oe_event_contact
 entity_type: node

--- a/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_venue.yml
+++ b/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_venue.yml
@@ -7,6 +7,10 @@ dependencies:
     - oe_content_entity_venue.oe_venue_type.oe_default
   module:
     - entity_reference_revisions
+    - oe_content
+third_party_settings:
+  oe_content:
+    composite: true
 id: node.oe_event.oe_event_venue
 field_name: oe_event_venue
 entity_type: node

--- a/oe_content.module
+++ b/oe_content.module
@@ -123,14 +123,10 @@ function oe_content_form_field_config_edit_form_alter(&$form, FormStateInterface
     return;
   }
   $form['composite'] = [
-    '#type' => 'radios',
+    '#type' => 'checkbox',
     '#title' => t('Composite field'),
     '#description' => t('Composite reference fields ensure that referenced entities get deleted when the referencing entity is deleted.'),
-    '#default_value' => $field_config->getThirdPartySetting('oe_content', 'composite') ?? 0,
-    '#options' => [
-      1 => t('Enabled'),
-      0 => t('Disabled'),
-    ],
+    '#default_value' => $field_config->getThirdPartySetting('oe_content', 'composite') ?? FALSE,
   ];
 
   $form['#entity_builders'][] = 'oe_content_form_field_config_form_builder';
@@ -152,7 +148,7 @@ function oe_content_form_field_config_edit_form_alter(&$form, FormStateInterface
  *   The form state.
  */
 function oe_content_form_field_config_form_builder(string $entity_type, FieldConfigInterface $field_config, array &$form, FormStateInterface $form_state): void {
-  $field_config->setThirdPartySetting('oe_content', 'composite', (bool) $form_state->getValue('composite'));
+  $field_config->setThirdPartySetting('oe_content', 'composite', $form_state->getValue('composite'));
 }
 
 /**

--- a/oe_content.module
+++ b/oe_content.module
@@ -7,9 +7,12 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\field\FieldConfigInterface;
 use Drupal\link\LinkItemInterface;
 
 /**
@@ -106,3 +109,126 @@ function oe_content_entity_base_field_info(EntityTypeInterface $entity_type) {
 function oe_content_locale_translation_projects_alter(&$projects) {
   $projects['oe_content']['info']['interface translation server pattern'] = drupal_get_path('module', 'oe_content') . '/translations/%project-%language.po';
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Add the composite field option to entity reference fields
+ */
+function oe_content_form_field_config_edit_form_alter(&$form, FormStateInterface $form_state): void {
+  /** @var \Drupal\field\FieldConfigInterface $field_config */
+  $field_config = $form_state->getFormObject()->getEntity();
+  $applicable_field_types = ['entity_reference', 'entity_reference_revisions'];
+  if (!in_array($field_config->getType(), $applicable_field_types)) {
+    return;
+  }
+  $form['composite'] = [
+    '#type' => 'radios',
+    '#title' => t('Composite field'),
+    '#description' => t('Making this field a composite field will delete any referenced entity if the referencing entity is deleted (only if the referenced entity is not referenced by some other entity).'),
+    '#default_value' => $field_config->getThirdPartySetting('oe_content', 'composite') ? 1 : 0,
+    '#options' => [
+      1 => t('Enabled'),
+      0 => t('Disabled'),
+    ],
+  ];
+
+  $form['#entity_builders'][] = 'oe_content_form_field_config_form_builder';
+
+}
+
+/**
+ * Entity form builder for the field_config form.
+ *
+ * Saves the composite field settings into the field config settings.
+ *
+ * @param string $entity_type
+ *   The name of the entity type.
+ * @param \Drupal\field\FieldConfigInterface $type
+ *   The field config.
+ * @param array $form
+ *   The form array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ */
+function oe_content_form_field_config_form_builder(string $entity_type, FieldConfigInterface $type, array &$form, FormStateInterface $form_state): void {
+  if ($form_state->getValue('composite')) {
+    $type->setThirdPartySetting('oe_content', 'composite', TRUE);
+  }
+  else {
+    $type->setThirdPartySetting('oe_content', 'composite', FALSE);
+  }
+}
+
+/**
+ * Implements hook_entity_delete().
+ */
+function oe_content_entity_delete(EntityInterface $entity): void {
+  if (!$entity instanceof \Drupal\Core\Entity\FieldableEntityInterface) {
+    return;
+  }
+  /** @var \Drupal\Core\Field\FieldDefinitionInterface[] $field_definitions */
+  $field_definitions = \Drupal::service('entity_field.manager')->getFieldDefinitions($entity->getEntityTypeId(), $entity->bundle());
+  $applicable_field_types = ['entity_reference', 'entity_reference_revisions'];
+  foreach ($field_definitions as $key => $definition) {
+    if (!in_array($definition->getType(), $applicable_field_types)) {
+      continue;
+    }
+    if ($definition instanceof FieldConfigInterface && $definition->getThirdPartySetting('oe_content', 'composite', FALSE)) {
+      $referenced_entities = $entity->get($key)->referencedEntities();
+      /** @var \Drupal\Core\Entity\EntityInterface $referenced_entity */
+      foreach ($referenced_entities as $referenced_entity) {
+        if ($referenced_entity->id() !== $entity->id() && oe_content_referenced_entity_deletable($referenced_entity)) {
+          $referenced_entity->delete();
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Checks whether we can delete a referenced entity or not.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity being checked.
+ *
+ * @return bool
+ *   TRUE if the entity is not referneced anywhere else, FALSE otherwise.
+ */
+function oe_content_referenced_entity_deletable(EntityInterface $entity): bool {
+  $entity_type_manager = \Drupal::entityTypeManager();
+
+  // Getting fields which could have references to the entity
+  // we are trying to delete.
+  $fields = $entity_type_manager->getStorage('field_config')->loadByProperties([
+    'field_type' => 'entity_reference',
+  ]);
+  $fields = array_merge($fields, $entity_type_manager->getStorage('field_config')->loadByProperties([
+    'field_type' => 'entity_reference_revisions',
+  ]));
+  $field_referenced_to_entity = [];
+  /** @var \Drupal\field\FieldConfigInterface $field */
+  foreach ($fields as $field) {
+    $field_settings = $field->getSettings();
+    if ($field_settings['handler'] === 'default:' . $entity->getEntityTypeId()) {
+      $field_referenced_to_entity[$field->getTargetEntityTypeId()][] = $field->getName();
+    }
+  }
+
+  // If any other entity is referencing our entity, return FALSE;
+  foreach ($field_referenced_to_entity as $entity_type_id => $field_names) {
+    $query = $entity_type_manager->getStorage($entity_type_id)->getQuery('OR');
+    foreach ($field_names as $field_name) {
+      $query->condition($field_name, $entity->id());
+    }
+    $ids = $query->execute();
+    if ($ids) {
+      return FALSE;
+    }
+  }
+
+  // If we didn't find any entity referencing our entity, return TRUE.
+  return TRUE;
+}
+
+

--- a/oe_content.module
+++ b/oe_content.module
@@ -144,24 +144,26 @@ function oe_content_form_field_config_edit_form_alter(&$form, FormStateInterface
  *
  * @param string $entity_type
  *   The name of the entity type.
- * @param \Drupal\field\FieldConfigInterface $type
+ * @param \Drupal\field\FieldConfigInterface $field_config
  *   The field config.
  * @param array $form
  *   The form array.
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The form state.
  */
-function oe_content_form_field_config_form_builder(string $entity_type, FieldConfigInterface $type, array &$form, FormStateInterface $form_state): void {
+function oe_content_form_field_config_form_builder(string $entity_type, FieldConfigInterface $field_config, array &$form, FormStateInterface $form_state): void {
   if ($form_state->getValue('composite')) {
-    $type->setThirdPartySetting('oe_content', 'composite', TRUE);
+    $field_config->setThirdPartySetting('oe_content', 'composite', TRUE);
   }
   else {
-    $type->setThirdPartySetting('oe_content', 'composite', FALSE);
+    $field_config->setThirdPartySetting('oe_content', 'composite', FALSE);
   }
 }
 
 /**
  * Implements hook_entity_delete().
+ *
+ * Delete any composite referenced entities when deleting an entity.
  */
 function oe_content_entity_delete(EntityInterface $entity): void {
   if (!$entity instanceof \Drupal\Core\Entity\FieldableEntityInterface) {

--- a/oe_content.module
+++ b/oe_content.module
@@ -126,10 +126,10 @@ function oe_content_form_field_config_edit_form_alter(&$form, FormStateInterface
     '#type' => 'radios',
     '#title' => t('Composite field'),
     '#description' => t('Composite reference fields ensure that referenced entities get deleted when the referencing entity is deleted..'),
-    '#default_value' => $field_config->getThirdPartySetting('oe_content', 'composite') ?? FALSE,
+    '#default_value' => $field_config->getThirdPartySetting('oe_content', 'composite') ?? 0,
     '#options' => [
-      TRUE => t('Enabled'),
-      FALSE => t('Disabled'),
+      1 => t('Enabled'),
+      0 => t('Disabled'),
     ],
   ];
 

--- a/oe_content.module
+++ b/oe_content.module
@@ -125,7 +125,7 @@ function oe_content_form_field_config_edit_form_alter(&$form, FormStateInterface
   $form['composite'] = [
     '#type' => 'radios',
     '#title' => t('Composite field'),
-    '#description' => t('Composite reference fields ensure that referenced entities get deleted when the referencing entity is deleted..'),
+    '#description' => t('Composite reference fields ensure that referenced entities get deleted when the referencing entity is deleted.'),
     '#default_value' => $field_config->getThirdPartySetting('oe_content', 'composite') ?? 0,
     '#options' => [
       1 => t('Enabled'),
@@ -173,6 +173,6 @@ function oe_content_entity_delete(EntityInterface $entity): void {
     if (!in_array($definition->getType(), $applicable_field_types)) {
       continue;
     }
-    $composite_reference_field_manager->deleteCompositeReferences($entity, $definition);
+    $composite_reference_field_manager->onDelete($entity, $definition);
   }
 }

--- a/oe_content.module
+++ b/oe_content.module
@@ -125,11 +125,11 @@ function oe_content_form_field_config_edit_form_alter(&$form, FormStateInterface
   $form['composite'] = [
     '#type' => 'radios',
     '#title' => t('Composite field'),
-    '#description' => t('Making this field a composite field will delete any referenced entity if the referencing entity is deleted (only if the referenced entity is not referenced by some other entity).'),
-    '#default_value' => $field_config->getThirdPartySetting('oe_content', 'composite') ? 1 : 0,
+    '#description' => t('Composite reference fields ensure that referenced entities get deleted when the referencing entity is deleted..'),
+    '#default_value' => $field_config->getThirdPartySetting('oe_content', 'composite') ?? FALSE,
     '#options' => [
-      1 => t('Enabled'),
-      0 => t('Disabled'),
+      TRUE => t('Enabled'),
+      FALSE => t('Disabled'),
     ],
   ];
 
@@ -152,12 +152,7 @@ function oe_content_form_field_config_edit_form_alter(&$form, FormStateInterface
  *   The form state.
  */
 function oe_content_form_field_config_form_builder(string $entity_type, FieldConfigInterface $field_config, array &$form, FormStateInterface $form_state): void {
-  if ($form_state->getValue('composite')) {
-    $field_config->setThirdPartySetting('oe_content', 'composite', TRUE);
-  }
-  else {
-    $field_config->setThirdPartySetting('oe_content', 'composite', FALSE);
-  }
+  $field_config->setThirdPartySetting('oe_content', 'composite', (bool) $form_state->getValue('composite'));
 }
 
 /**

--- a/oe_content.module
+++ b/oe_content.module
@@ -167,65 +167,12 @@ function oe_content_entity_delete(EntityInterface $entity): void {
   /** @var \Drupal\Core\Field\FieldDefinitionInterface[] $field_definitions */
   $field_definitions = \Drupal::service('entity_field.manager')->getFieldDefinitions($entity->getEntityTypeId(), $entity->bundle());
   $applicable_field_types = ['entity_reference', 'entity_reference_revisions'];
+  /** @var \Drupal\oe_content\CompositeReferenceFieldManagerInterface $composite_reference_field_manager */
+  $composite_reference_field_manager = \Drupal::service('oe_content.composite_reference_field_manager');
   foreach ($field_definitions as $key => $definition) {
     if (!in_array($definition->getType(), $applicable_field_types)) {
       continue;
     }
-    if ($definition instanceof FieldConfigInterface && $definition->getThirdPartySetting('oe_content', 'composite', FALSE)) {
-      $referenced_entities = $entity->get($key)->referencedEntities();
-      /** @var \Drupal\Core\Entity\EntityInterface $referenced_entity */
-      foreach ($referenced_entities as $referenced_entity) {
-        if ($referenced_entity->id() !== $entity->id() && oe_content_referenced_entity_deletable($referenced_entity)) {
-          $referenced_entity->delete();
-        }
-      }
-    }
+    $composite_reference_field_manager->deleteCompositeReferences($entity, $definition);
   }
 }
-
-/**
- * Checks whether we can delete a referenced entity or not.
- *
- * @param \Drupal\Core\Entity\EntityInterface $entity
- *   The entity being checked.
- *
- * @return bool
- *   TRUE if the entity is not referneced anywhere else, FALSE otherwise.
- */
-function oe_content_referenced_entity_deletable(EntityInterface $entity): bool {
-  $entity_type_manager = \Drupal::entityTypeManager();
-
-  // Getting fields which could have references to the entity
-  // we are trying to delete.
-  $fields = $entity_type_manager->getStorage('field_config')->loadByProperties([
-    'field_type' => 'entity_reference',
-  ]);
-  $fields = array_merge($fields, $entity_type_manager->getStorage('field_config')->loadByProperties([
-    'field_type' => 'entity_reference_revisions',
-  ]));
-  $field_referenced_to_entity = [];
-  /** @var \Drupal\field\FieldConfigInterface $field */
-  foreach ($fields as $field) {
-    $field_settings = $field->getSettings();
-    if ($field_settings['handler'] === 'default:' . $entity->getEntityTypeId()) {
-      $field_referenced_to_entity[$field->getTargetEntityTypeId()][] = $field->getName();
-    }
-  }
-
-  // If any other entity is referencing our entity, return FALSE;
-  foreach ($field_referenced_to_entity as $entity_type_id => $field_names) {
-    $query = $entity_type_manager->getStorage($entity_type_id)->getQuery('OR');
-    foreach ($field_names as $field_name) {
-      $query->condition($field_name, $entity->id());
-    }
-    $ids = $query->execute();
-    if ($ids) {
-      return FALSE;
-    }
-  }
-
-  // If we didn't find any entity referencing our entity, return TRUE.
-  return TRUE;
-}
-
-

--- a/oe_content.services.yml
+++ b/oe_content.services.yml
@@ -6,4 +6,4 @@ services:
     arguments: ['@config.factory']
   oe_content.composite_reference_field_manager:
     class: Drupal\oe_content\CompositeReferenceFieldManager
-    arguments: ['@entity_type.manager']
+    arguments: ['@entity_type.manager', '@entity_field.manager']

--- a/oe_content.services.yml
+++ b/oe_content.services.yml
@@ -4,3 +4,6 @@ services:
   oe_content.op_skos_setup:
     class: Drupal\oe_content\PublicationsOfficeSkosGraphSetup
     arguments: ['@config.factory']
+  oe_content.composite_reference_field_manager:
+    class: Drupal\oe_content\CompositeReferenceFieldManager
+    arguments: ['@entity_type.manager']

--- a/src/CompositeReferenceFieldManager.php
+++ b/src/CompositeReferenceFieldManager.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_content;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\field\FieldConfigInterface;
+
+/**
+ * Manager class for composite reference fields.
+ *
+ * @package Drupal\oe_content
+ */
+class CompositeReferenceFieldManager implements CompositeReferenceFieldManagerInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * CompositeReferenceFieldManager constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getReferencingEntities(EntityInterface $entity): array {
+    $referencing_entities = [];
+    // Getting all fields which could have references to the given entity.
+    $fields = $this->entityTypeManager->getStorage('field_config')->loadByProperties([
+      'field_type' => 'entity_reference',
+    ]);
+    $fields = array_merge($fields, $this->entityTypeManager->getStorage('field_config')->loadByProperties([
+      'field_type' => 'entity_reference_revisions',
+    ]));
+
+    // Only check fields that handle the given entity type.
+    $field_referenced_to_entity = [];
+    /** @var \Drupal\field\FieldConfigInterface $field */
+    foreach ($fields as $field) {
+      $field_settings = $field->getSettings();
+      if ($field_settings['handler'] === 'default:' . $entity->getEntityTypeId()) {
+        $field_referenced_to_entity[$field->getTargetEntityTypeId()][] = $field->getName();
+      }
+    }
+
+    // Load all entities that have a reference to the given entity.
+    foreach ($field_referenced_to_entity as $entity_type_id => $field_names) {
+      $query = $this->entityTypeManager->getStorage($entity_type_id)->getQuery('OR');
+      foreach ($field_names as $field_name) {
+        $query->condition($field_name, $entity->id());
+      }
+      $ids = $query->execute();
+      if ($ids) {
+        $referencing_entities = array_merge($referencing_entities, $ids);
+      }
+    }
+    return $referencing_entities;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteCompositeReferences(EntityInterface $entity, FieldDefinitionInterface $field_definition): void {
+    if ($field_definition instanceof FieldConfigInterface && $field_definition->getThirdPartySetting('oe_content', 'composite', FALSE)) {
+      $referenced_entities = $entity->get($field_definition->getName())->referencedEntities();
+      /** @var \Drupal\Core\Entity\EntityInterface $referenced_entity */
+      foreach ($referenced_entities as $referenced_entity) {
+        if ($referenced_entity->id() !== $entity->id() && empty($this->getReferencingEntities($referenced_entity))) {
+          $referenced_entity->delete();
+        }
+      }
+    }
+  }
+
+}

--- a/src/CompositeReferenceFieldManager.php
+++ b/src/CompositeReferenceFieldManager.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_content;
 
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
@@ -24,13 +26,23 @@ class CompositeReferenceFieldManager implements CompositeReferenceFieldManagerIn
   protected $entityTypeManager;
 
   /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
    * CompositeReferenceFieldManager constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entityFieldManager
+   *   The entity field manager.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entityFieldManager) {
     $this->entityTypeManager = $entity_type_manager;
+    $this->entityFieldManager = $entityFieldManager;
   }
 
   /**
@@ -38,24 +50,12 @@ class CompositeReferenceFieldManager implements CompositeReferenceFieldManagerIn
    */
   public function getReferencingEntities(EntityInterface $entity): array {
     $referencing_entities = [];
-    // Get all entity reference fields that reference this entity type.
-    $field_config_storage = $this->entityTypeManager->getStorage('field_config');
-    $entity_reference_field_ids = $field_config_storage->getQuery()
-      ->condition('field_type', ['entity_reference', 'entity_reference_revisions'], 'IN')
-      ->condition('settings.handler', 'default:' . $entity->getEntityTypeId())
-      ->execute();
 
-    $entity_reference_fields = $field_config_storage->loadMultiple($entity_reference_field_ids);
-
-    // Group the fields by their target entity type.
-    $grouped_fields = [];
-    foreach ($entity_reference_fields as $field_name => $field) {
-      $grouped_fields[$field->getTargetEntityTypeId()][] = $field->getName();
-    }
+    $reference_fields = $this->getReferenceFields($entity->getEntityTypeId());
 
     // Load all entities that have a reference to the given entity.
-    foreach ($grouped_fields as $field_entity_type_id => $field_names) {
-      $entity_type_storage = $this->entityTypeManager->getStorage($field_entity_type_id);
+    foreach ($reference_fields as $entity_type => $field_names) {
+      $entity_type_storage = $this->entityTypeManager->getStorage($entity_type);
       $query = $entity_type_storage->getQuery('OR');
       foreach ($field_names as $field_name) {
         $query->condition($field_name, $entity->id());
@@ -83,6 +83,33 @@ class CompositeReferenceFieldManager implements CompositeReferenceFieldManagerIn
         }
       }
     }
+  }
+
+  /**
+   * Get the fields that reference entities of this type.
+   *
+   * @param string $entity_type
+   *   The entity type.
+   *
+   * @return array
+   *   An array of field names, keyed by the entity type they reference from.
+   */
+  protected function getReferenceFields(string $entity_type): array {
+    $entity_reference_map = $this->entityFieldManager->getFieldMapByFieldType('entity_reference');
+    $entity_reference_revisions_map = $this->entityFieldManager->getFieldMapByFieldType('entity_reference_revisions');
+    $map = NestedArray::mergeDeep($entity_reference_map, $entity_reference_revisions_map);
+    $reference_fields = [];
+    foreach ($map as $entity_type => $fields) {
+      $definitions = array_filter($this->entityFieldManager->getFieldStorageDefinitions($entity_type), function ($definition, $field_name) use ($fields, $entity_type) {
+        // Include only the fields types from our map and that reference the
+        // entity type of the passed entity.
+        return in_array($field_name, array_keys($fields)) && $definition->getSetting('target_type') === $entity_type;
+      }, ARRAY_FILTER_USE_BOTH);
+
+      $reference_fields[$entity_type] = array_keys($definitions);
+    }
+
+    return array_filter($reference_fields);
   }
 
 }

--- a/src/CompositeReferenceFieldManagerInterface.php
+++ b/src/CompositeReferenceFieldManagerInterface.php
@@ -8,7 +8,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 
 /**
- * Interface for CompositeReferenceFieldManager classes.
+ * Defines composite reference field managers.
  *
  * @package Drupal\oe_content
  */
@@ -26,13 +26,13 @@ interface CompositeReferenceFieldManagerInterface {
   public function getReferencingEntities(EntityInterface $entity): array;
 
   /**
-   * Deletes the entities referenced in a field for a given entity.
+   * Reacts to the deletion of an entity and deletes its composite references.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The referencing entity.
    * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
    *   The definition of the field to remove references from.
    */
-  public function deleteCompositeReferences(EntityInterface $entity, FieldDefinitionInterface $field_definition): void;
+  public function onDelete(EntityInterface $entity, FieldDefinitionInterface $field_definition): void;
 
 }

--- a/src/CompositeReferenceFieldManagerInterface.php
+++ b/src/CompositeReferenceFieldManagerInterface.php
@@ -15,7 +15,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 interface CompositeReferenceFieldManagerInterface {
 
   /**
-   * Returns a list of possible entities that reference the given entity.
+   * Returns a list of possible entities that reference a given entity.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The referenced entity.

--- a/src/CompositeReferenceFieldManagerInterface.php
+++ b/src/CompositeReferenceFieldManagerInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_content;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+
+/**
+ * Interface for CompositeReferenceFieldManager classes.
+ *
+ * @package Drupal\oe_content
+ */
+interface CompositeReferenceFieldManagerInterface {
+
+  /**
+   * Returns a list of possible entities that reference the given entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The referenced entity.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface[]
+   *   An array of entities that reference the given entity.
+   */
+  public function getReferencingEntities(EntityInterface $entity): array;
+
+  /**
+   * Deletes the entities referenced in a field for a given entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The referencing entity.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to remove references from.
+   */
+  public function deleteCompositeReferences(EntityInterface $entity, FieldDefinitionInterface $field_definition): void;
+
+}

--- a/tests/Functional/CompositeReferenceConfigurationTest.php
+++ b/tests/Functional/CompositeReferenceConfigurationTest.php
@@ -16,6 +16,7 @@ use Drupal\Tests\oe_content\Traits\CompositeReferenceTestTrait;
 class CompositeReferenceConfigurationTest extends BrowserTestBase {
 
   use CompositeReferenceTestTrait;
+
   /**
    * {@inheritdoc}
    */
@@ -42,21 +43,12 @@ class CompositeReferenceConfigurationTest extends BrowserTestBase {
 
   /**
    * Asserts that field forms have the composite option if applicable.
-   *
-   * @dataProvider compositeFieldDefinitions
    */
-  public function testCompositeReferenceConfiguration(string $field_name, string $field_label, bool $revisions): void {
+  public function testCompositeReferenceConfiguration(): void {
     $entity_type_manager = \Drupal::entityTypeManager();
     // Create a content type.
     $node_type = $entity_type_manager->getStorage('node_type')->create(['name' => 'Test content type', 'type' => 'test_ct']);
     $node_type->save();
-
-    // Create an entity reference field.
-    $entity_reference_field = $this->createEntityReferenceField('node', $node_type->id(), $field_name, $field_label, 'node', 'default', [
-      'target_bundles' => [
-        $node_type->id() => $node_type->id(),
-      ],
-    ], 1, $revisions);
 
     // Create a text field.
     $entity_type_manager->getStorage('field_storage_config')->create([
@@ -74,32 +66,55 @@ class CompositeReferenceConfigurationTest extends BrowserTestBase {
     ]);
     $text_field->save();
 
-    // Access the text field edit form and assert that the composite
-    // option is not available.
-    $url = Url::fromRoute("entity.field_config.node_field_edit_form", ['node_type' => $node_type->id(), 'field_config' => $text_field->id()]);
-    $this->drupalGet($url);
-    $this->assertSession()->pageTextContains('Text field settings for Test content type');
-    $this->assertSession()->pageTextNotContains('Composite field');
+    $reference_field_definitions = [
+      [
+        'field_name' => 'entity_reference_field',
+        'field_label' => 'Entity reference field',
+        'revisions' => FALSE,
+      ],
+      [
+        'field_name' => 'entity_reference_revisions_field',
+        'field_label' => 'Entity reference revisions field',
+        'revisions' => TRUE,
+      ],
+    ];
 
-    // Access the text entity reference edit form and assert that the composite
-    // option is available.
-    $url = Url::fromRoute("entity.field_config.node_field_edit_form", ['node_type' => $node_type->id(), 'field_config' => $entity_reference_field->id()]);
-    $this->drupalGet($url);
-    $this->assertSession()->pageTextContains($field_label . ' settings for Test content type');
-    // The configuration is disabled by default.
-    $this->assertSession()->checkboxNotChecked('Composite field');
-    // Enable the composite reference and save it.
-    $this->getSession()->getPage()->checkField('Composite field');
-    $this->getSession()->getPage()->pressButton('Save settings');
+    foreach ($reference_field_definitions as $field_definition) {
+      // Create an entity reference field.
+      $entity_reference_field = $this->createEntityReferenceField('node', $node_type->id(), $field_definition['field_name'], $field_definition['field_label'], 'node', 'default', [
+        'target_bundles' => [
+          $node_type->id() => $node_type->id(),
+        ],
+      ], 1, $field_definition['revisions']);
 
-    // Load the field configuration and assert the changes where saved.
-    $entity_reference_field = $entity_type_manager->getStorage('field_config')->load($entity_reference_field->id());
-    $this->assertEqual($entity_reference_field->getThirdPartySetting('oe_content', 'composite'), TRUE);
-    // Reload the page and assert the changes are reflected.
-    $this->drupalGet($url);
-    $this->assertSession()->pageTextContains($field_label . ' settings for Test content type');
-    // The configuration is enabled.
-    $this->assertSession()->checkboxChecked('Composite field');
+      // Access the text field edit form and assert that the composite
+      // option is not available.
+      $url = Url::fromRoute("entity.field_config.node_field_edit_form", ['node_type' => $node_type->id(), 'field_config' => $text_field->id()]);
+      $this->drupalGet($url);
+      $this->assertSession()->pageTextContains('Text field settings for Test content type');
+      $this->assertSession()->pageTextNotContains('Composite field');
+
+      // Access the text entity reference edit form
+      // and assert that the composite option is available.
+      $url = Url::fromRoute("entity.field_config.node_field_edit_form", ['node_type' => $node_type->id(), 'field_config' => $entity_reference_field->id()]);
+      $this->drupalGet($url);
+      $this->assertSession()->pageTextContains($field_definition['field_label'] . ' settings for Test content type');
+      // The configuration is disabled by default.
+      $this->assertSession()->checkboxNotChecked('Composite field');
+      // Enable the composite reference and save it.
+      $this->getSession()->getPage()->checkField('Composite field');
+      $this->getSession()->getPage()->pressButton('Save settings');
+
+      // Load the field configuration and assert the changes where saved.
+      $entity_reference_field = $entity_type_manager->getStorage('field_config')->load($entity_reference_field->id());
+      $this->assertEqual($entity_reference_field->getThirdPartySetting('oe_content', 'composite'), TRUE);
+      // Reload the page and assert the changes are reflected.
+      $this->drupalGet($url);
+      $this->assertSession()->pageTextContains($field_definition['field_label'] . ' settings for Test content type');
+      // The configuration is enabled.
+      $this->assertSession()->checkboxChecked('Composite field');
+    }
+
   }
 
 }

--- a/tests/Functional/CompositeReferenceConfigurationTest.php
+++ b/tests/Functional/CompositeReferenceConfigurationTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_content\Functional;
+
+use Drupal\Core\Url;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Functional tests for composite reference configuration forms.
+ *
+ * @package Drupal\Tests\oe_content\Functional
+ */
+class CompositeReferenceConfigurationTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'field_ui',
+    'node',
+    'field',
+    'user',
+    'oe_content',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $permissions[] = 'administer node fields';
+    $user = $this->drupalCreateUser($permissions);
+
+    $this->drupalLogin($user);
+  }
+
+  /**
+   * Asserts that field forms have the composite option if applicable.
+   */
+  public function testCompositeReferenceConfiguration(): void {
+    $entity_type_manager = \Drupal::entityTypeManager();
+    // Create a content type.
+    $node_type = $entity_type_manager->getStorage('node_type')->create(['name' => 'Test content type', 'type' => 'test_ct']);
+    $node_type->save();
+
+    // Create an entity reference field.
+    $entity_type_manager->getStorage('field_storage_config')->create([
+      'entity_type' => 'node',
+      'field_name' => 'entity_reference_field',
+      'type' => 'entity_reference',
+      'cardinality' => 1,
+    ])->save();
+    /** @var \Drupal\field\FieldConfigInterface $entity_reference_field */
+    $entity_reference_field = $entity_type_manager->getStorage('field_config')->create([
+      'entity_type' => 'node',
+      'field_name' => 'entity_reference_field',
+      'bundle' => $node_type->id(),
+      'label' => 'Entity reference field',
+      'translatable' => FALSE,
+      'settings' => [
+        'handler' => 'default:node',
+        'handler_settings' => [
+          'target_bundles' => [
+            'test_ct' => 'test_ct',
+          ],
+        ],
+      ],
+    ]);
+    $entity_reference_field->save();
+
+    // Create a text field.
+    // Create an entity reference field.
+    $entity_type_manager->getStorage('field_storage_config')->create([
+      'entity_type' => 'node',
+      'field_name' => 'text_field',
+      'type' => 'text_long',
+      'cardinality' => 1,
+    ])->save();
+    $text_field = $entity_type_manager->getStorage('field_config')->create([
+      'entity_type' => 'node',
+      'field_name' => 'text_field',
+      'bundle' => $node_type->id(),
+      'label' => 'Text field',
+      'translatable' => TRUE,
+    ]);
+    $text_field->save();
+
+    // Access the text field edit form and assert that the composite
+    // option is not available.
+    $url = Url::fromRoute("entity.field_config.node_field_edit_form", ['node_type' => $node_type->id(), 'field_config' => $text_field->id()]);
+    $this->drupalGet($url);
+    $this->assertSession()->pageTextContains('Text field settings for Test content type');
+    $this->assertSession()->pageTextNotContains('Composite field');
+
+    // Access the text entity reference edit form and assert that the composite
+    // option is available.
+    $url = Url::fromRoute("entity.field_config.node_field_edit_form", ['node_type' => $node_type->id(), 'field_config' => $entity_reference_field->id()]);
+    $this->drupalGet($url);
+    $this->assertSession()->pageTextContains('Entity reference field settings for Test content type');
+    $this->assertSession()->pageTextContains('Composite field');
+    // The configuration is disabled by default.
+    $this->assertSession()->checkboxChecked('Disabled');
+    $this->assertSession()->checkboxNotChecked('Enabled');
+    // Enable the composite reference and save it.
+    $this->getSession()->getPage()->selectFieldOption('composite', '1');
+    $this->getSession()->getPage()->pressButton('Save settings');
+
+    // Reload the page and assert the changes where saved.
+    $this->drupalGet($url);
+    $this->assertSession()->pageTextContains('Entity reference field settings for Test content type');
+    $this->assertSession()->pageTextContains('Composite field');
+    // The configuration is enabled.
+    $this->assertSession()->checkboxNotChecked('Disabled');
+    $this->assertSession()->checkboxChecked('Enabled');
+  }
+
+}

--- a/tests/Functional/CompositeReferenceConfigurationTest.php
+++ b/tests/Functional/CompositeReferenceConfigurationTest.php
@@ -86,12 +86,10 @@ class CompositeReferenceConfigurationTest extends BrowserTestBase {
     $url = Url::fromRoute("entity.field_config.node_field_edit_form", ['node_type' => $node_type->id(), 'field_config' => $entity_reference_field->id()]);
     $this->drupalGet($url);
     $this->assertSession()->pageTextContains($field_label . ' settings for Test content type');
-    $this->assertSession()->pageTextContains('Composite field');
     // The configuration is disabled by default.
-    $this->assertSession()->checkboxChecked('Disabled');
-    $this->assertSession()->checkboxNotChecked('Enabled');
+    $this->assertSession()->checkboxNotChecked('Composite field');
     // Enable the composite reference and save it.
-    $this->getSession()->getPage()->selectFieldOption('composite', '1');
+    $this->getSession()->getPage()->checkField('Composite field');
     $this->getSession()->getPage()->pressButton('Save settings');
 
     // Load the field configuration and assert the changes where saved.
@@ -100,10 +98,8 @@ class CompositeReferenceConfigurationTest extends BrowserTestBase {
     // Reload the page and assert the changes are reflected.
     $this->drupalGet($url);
     $this->assertSession()->pageTextContains($field_label . ' settings for Test content type');
-    $this->assertSession()->pageTextContains('Composite field');
     // The configuration is enabled.
-    $this->assertSession()->checkboxNotChecked('Disabled');
-    $this->assertSession()->checkboxChecked('Enabled');
+    $this->assertSession()->checkboxChecked('Composite field');
   }
 
 }

--- a/tests/Kernel/CompositeFieldsTest.php
+++ b/tests/Kernel/CompositeFieldsTest.php
@@ -13,10 +13,9 @@ use Drupal\Tests\rdf_entity\Kernel\RdfKernelTestBase;
 class CompositeFieldsTest extends RdfKernelTestBase {
 
   use CompositeReferenceTestTrait;
+
   /**
-   * Modules to enable.
-   *
-   * @var array
+   * {@inheritdoc}
    */
   public static $modules = [
     'field',
@@ -46,134 +45,147 @@ class CompositeFieldsTest extends RdfKernelTestBase {
 
   /**
    * Test the composite option of entity reference fields.
-   *
-   * @dataProvider compositeFieldDefinitions
    */
-  public function testCompositeOption(string $field_name, string $field_label, bool $revisions): void {
+  public function testCompositeOption(): void {
     $entity_type_manager = $this->container->get('entity_type.manager');
     // Create a test content type.
     $type = $entity_type_manager->getStorage('node_type')->create(['name' => 'Test content type', 'type' => 'test_ct']);
     $type->save();
 
-    // Create an entity reference field for the test content type.
-    $entity_reference_field = $this->createEntityReferenceField('node', $type->id(), $field_name, $field_label, 'node', 'default', [
-      'target_bundles' => [
-        $type->id() => $type->id(),
+    $reference_field_definitions = [
+      [
+        'field_name' => 'entity_reference_field',
+        'field_label' => 'Entity reference field',
+        'revisions' => FALSE,
       ],
-    ], 1, $revisions);
-    // Configure the entity reference field to not be composite.
-    $entity_reference_field->setThirdPartySetting('oe_content', 'composite', FALSE);
-    $entity_reference_field->save();
-
-    // Create a node that will be referenced by the others.
-    $node_storage = $entity_type_manager->getStorage('node');
-    $values = [
-      'type' => $type->id(),
-      'title' => 'Referenced node',
-    ];
-    /** @var \Drupal\node\NodeInterface $referenced_node */
-    $referenced_node = $node_storage->create($values);
-    $referenced_node->save();
-
-    // Assert that while an entity reference field is not composite,
-    // deleting a node will not delete any entities that it may be
-    // referencing.
-    // Create a node that references the first node
-    // and delete it right after.
-    $values = [
-      'type' => $type->id(),
-      'title' => 'Referencing node',
-      $field_name => [
-        'target_id' => $referenced_node->id(),
+      [
+        'field_name' => 'entity_reference_revisions_field',
+        'field_label' => 'Entity reference revisions field',
+        'revisions' => TRUE,
       ],
     ];
-    if ($revisions) {
-      $values[$field_name]['target_revision_id'] = $referenced_node->getLoadedRevisionId();
+
+    foreach ($reference_field_definitions as $field_definition) {
+      // Create an entity reference field for the test content type.
+      $entity_reference_field = $this->createEntityReferenceField('node', $type->id(), $field_definition['field_name'], $field_definition['field_label'], 'node', 'default', [
+        'target_bundles' => [
+          $type->id() => $type->id(),
+        ],
+      ], 1, $field_definition['revisions']);
+      // Configure the entity reference field to not be composite.
+      $entity_reference_field->setThirdPartySetting('oe_content', 'composite', FALSE);
+      $entity_reference_field->save();
+
+      // Create a node that will be referenced by the others.
+      $node_storage = $entity_type_manager->getStorage('node');
+      $values = [
+        'type' => $type->id(),
+        'title' => 'Referenced node',
+      ];
+      /** @var \Drupal\node\NodeInterface $referenced_node */
+      $referenced_node = $node_storage->create($values);
+      $referenced_node->save();
+
+      // Assert that while an entity reference field is not composite,
+      // deleting a node will not delete any entities that it may be
+      // referencing.
+      // Create a node that references the first node
+      // and delete it right after.
+      $values = [
+        'type' => $type->id(),
+        'title' => 'Referencing node',
+        $field_definition['field_name'] => [
+          'target_id' => $referenced_node->id(),
+        ],
+      ];
+      if ($field_definition['revisions']) {
+        $values[$field_definition['field_name']]['target_revision_id'] = $referenced_node->getLoadedRevisionId();
+      }
+      $referencing_node = $node_storage->create($values);
+      $referencing_node->save();
+      $referencing_node->delete();
+
+      // Reload the referenced node and assert it was not deleted because
+      // the entity reference field is not composite yet.
+      $node_storage->resetCache();
+      $referenced_node = $node_storage->load($referenced_node->id());
+      $this->assertNotEmpty($referenced_node);
+
+      // Assert that while an entity reference field is composite,
+      // deleting a node will not delete an entity it is referencing
+      // if another entity also references the same entity.
+      // Update the entity reference field configuration to be composite.
+      $entity_reference_field->setThirdPartySetting('oe_content', 'composite', TRUE);
+      $entity_reference_field->save();
+
+      // Create a node that references the first one.
+      $values = [
+        'type' => $type->id(),
+        'title' => 'Referencing node one',
+        $field_definition['field_name'] => [
+          'target_id' => $referenced_node->id(),
+        ],
+      ];
+      if ($field_definition['revisions']) {
+        $values[$field_definition['field_name']]['target_revision_id'] = $referenced_node->getLoadedRevisionId();
+      }
+      $referencing_node_one = $node_storage->create($values);
+      $referencing_node_one->save();
+
+      // Create a second node that that also references the first one
+      // and delete it right after.
+      $values = [
+        'type' => $type->id(),
+        'title' => 'Referencing node two',
+        $field_definition['field_name'] => [
+          'target_id' => $referenced_node->id(),
+        ],
+      ];
+      if ($field_definition['revisions']) {
+        $values[$field_definition['field_name']]['target_revision_id'] = $referenced_node->getLoadedRevisionId();
+      }
+      $referencing_node_two = $node_storage->create($values);
+      $referencing_node_two->save();
+      $referencing_node_two->delete();
+
+      // Reload the referenced node and assert it was not deleted because
+      // it is still being referenced by the first referencing node.
+      $node_storage->resetCache();
+      $referenced_node = $node_storage->load($referenced_node->id());
+      $this->assertNotEmpty($referenced_node);
+
+      // Assert that while an entity reference field is composite,
+      // deleting a node will delete an entity it is referencing
+      // if it is not referenced by any other entity.
+      // Update the first referencing node to stop referencing the first node.
+      $referencing_node_one->{$field_definition['field_name']}->target_id = '';
+      if ($field_definition['revisions']) {
+        $referencing_node_one->{$field_definition['field_name']}->target_revision_id = '';
+      }
+      $referencing_node_one->save();
+
+      // Create a third referencing node that that references the first one
+      // and delete it right after.
+      $values = [
+        'type' => $type->id(),
+        'title' => 'Referencing node three',
+        $field_definition['field_name'] => [
+          'target_id' => $referenced_node->id(),
+        ],
+      ];
+      if ($field_definition['revisions']) {
+        $values[$field_definition['field_name']]['target_revision_id'] = $referenced_node->getLoadedRevisionId();
+      }
+      $referencing_node_two_three = $node_storage->create($values);
+      $referencing_node_two_three->save();
+      $referencing_node_two_three->delete();
+
+      // Reload the referenced node and assert it has been deleted because
+      // there are no more nodes referencing it.
+      $node_storage->resetCache();
+      $referenced_node = $node_storage->load($referenced_node->id());
+      $this->assertEmpty($referenced_node);
     }
-    $referencing_node = $node_storage->create($values);
-    $referencing_node->save();
-    $referencing_node->delete();
-
-    // Reload the referenced node and assert it was not deleted because
-    // the entity reference field is not composite yet.
-    $node_storage->resetCache();
-    $referenced_node = $node_storage->load($referenced_node->id());
-    $this->assertNotEmpty($referenced_node);
-
-    // Assert that while an entity reference field is composite,
-    // deleting a node will not delete an entity it is referencing
-    // if another entity also references the same entity.
-    // Update the entity reference field configuration to be composite.
-    $entity_reference_field->setThirdPartySetting('oe_content', 'composite', TRUE);
-    $entity_reference_field->save();
-
-    // Create a node that references the first one.
-    $values = [
-      'type' => $type->id(),
-      'title' => 'Referencing node one',
-      $field_name => [
-        'target_id' => $referenced_node->id(),
-      ],
-    ];
-    if ($revisions) {
-      $values[$field_name]['target_revision_id'] = $referenced_node->getLoadedRevisionId();
-    }
-    $referencing_node_one = $node_storage->create($values);
-    $referencing_node_one->save();
-
-    // Create a second node that that also references the first one
-    // and delete it right after.
-    $values = [
-      'type' => $type->id(),
-      'title' => 'Referencing node two',
-      $field_name => [
-        'target_id' => $referenced_node->id(),
-      ],
-    ];
-    if ($revisions) {
-      $values[$field_name]['target_revision_id'] = $referenced_node->getLoadedRevisionId();
-    }
-    $referencing_node_two = $node_storage->create($values);
-    $referencing_node_two->save();
-    $referencing_node_two->delete();
-
-    // Reload the referenced node and assert it was not deleted because
-    // it is still being referenced by the first referencing node.
-    $node_storage->resetCache();
-    $referenced_node = $node_storage->load($referenced_node->id());
-    $this->assertNotEmpty($referenced_node);
-
-    // Assert that while an entity reference field is composite,
-    // deleting a node will delete an entity it is referencing
-    // if it is not referenced by any other entity.
-    // Update the first referencing node to stop referencing the first node.
-    $referencing_node_one->{$field_name}->target_id = '';
-    if ($revisions) {
-      $referencing_node_one->{$field_name}->target_revision_id = '';
-    }
-    $referencing_node_one->save();
-
-    // Create a third referencing node that that references the first one
-    // and delete it right after.
-    $values = [
-      'type' => $type->id(),
-      'title' => 'Referencing node three',
-      $field_name => [
-        'target_id' => $referenced_node->id(),
-      ],
-    ];
-    if ($revisions) {
-      $values[$field_name]['target_revision_id'] = $referenced_node->getLoadedRevisionId();
-    }
-    $referencing_node_two_three = $node_storage->create($values);
-    $referencing_node_two_three->save();
-    $referencing_node_two_three->delete();
-
-    // Reload the referenced node and assert it has been deleted because
-    // there are no more nodes referencing it.
-    $node_storage->resetCache();
-    $referenced_node = $node_storage->load($referenced_node->id());
-    $this->assertEmpty($referenced_node);
   }
 
 }

--- a/tests/Kernel/CompositeFieldsTest.php
+++ b/tests/Kernel/CompositeFieldsTest.php
@@ -43,9 +43,9 @@ class CompositeFieldsTest extends RdfKernelTestBase {
   }
 
   /**
-   * Test the defined fields.
+   * Test the composite option of entity reference fields.
    */
-  public function testBaseStorage(): void {
+  public function testCompositeOption(): void {
     $entity_type_manager = \Drupal::entityTypeManager();
     // Create a content type.
     $type = $entity_type_manager->getStorage('node_type')->create(['name' => 'Test content type', 'type' => 'test_ct']);

--- a/tests/Kernel/CompositeFieldsTest.php
+++ b/tests/Kernel/CompositeFieldsTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_content\Kernel;
 
+use Drupal\Tests\oe_content\Traits\CompositeReferenceTestTrait;
 use Drupal\Tests\rdf_entity\Kernel\RdfKernelTestBase;
 
 /**
@@ -11,6 +12,7 @@ use Drupal\Tests\rdf_entity\Kernel\RdfKernelTestBase;
  */
 class CompositeFieldsTest extends RdfKernelTestBase {
 
+  use CompositeReferenceTestTrait;
   /**
    * Modules to enable.
    *
@@ -25,6 +27,7 @@ class CompositeFieldsTest extends RdfKernelTestBase {
     'system',
     'text',
     'user',
+    'entity_reference_revisions',
   ];
 
   /**
@@ -43,117 +46,131 @@ class CompositeFieldsTest extends RdfKernelTestBase {
 
   /**
    * Test the composite option of entity reference fields.
+   *
+   * @dataProvider compositeFieldDefinitions
    */
-  public function testCompositeOption(): void {
-    $entity_type_manager = \Drupal::entityTypeManager();
-    // Create a content type.
+  public function testCompositeOption(string $field_name, string $field_label, bool $revisions): void {
+    $entity_type_manager = $this->container->get('entity_type.manager');
+    // Create a test content type.
     $type = $entity_type_manager->getStorage('node_type')->create(['name' => 'Test content type', 'type' => 'test_ct']);
     $type->save();
 
-    // Create an entity reference field.
-    $entity_type_manager->getStorage('field_storage_config')->create([
-      'entity_type' => 'node',
-      'field_name' => 'entity_reference_field',
-      'type' => 'entity_reference',
-      'cardinality' => 1,
-    ])->save();
-    /** @var \Drupal\field\FieldConfigInterface $entity_reference_field */
-    $entity_reference_field = $entity_type_manager->getStorage('field_config')->create([
-      'entity_type' => 'node',
-      'field_name' => 'entity_reference_field',
-      'bundle' => 'test_ct',
-      'label' => 'Entity reference field',
-      'translatable' => FALSE,
-      'settings' => [
-        'handler' => 'default:node',
-        'handler_settings' => [
-          'target_bundles' => [
-            'test_ct' => 'test_ct',
-          ],
-        ],
+    // Create an entity reference field for the test content type.
+    $entity_reference_field = $this->createEntityReferenceField('node', $type->id(), $field_name, $field_label, 'node', 'default', [
+      'target_bundles' => [
+        $type->id() => $type->id(),
       ],
-    ]);
+    ], 1, $revisions);
+    // Configure the entity reference field to not be composite.
     $entity_reference_field->setThirdPartySetting('oe_content', 'composite', FALSE);
     $entity_reference_field->save();
 
+    // Create a node that will be referenced by the others.
     $node_storage = $entity_type_manager->getStorage('node');
-    // Create an entity to be referenced.
     $values = [
-      'type' => 'test_ct',
-      'title' => 'Referenced entity',
+      'type' => $type->id(),
+      'title' => 'Referenced node',
     ];
+    /** @var \Drupal\node\NodeInterface $referenced_node */
     $referenced_node = $node_storage->create($values);
     $referenced_node->save();
 
-    // Create a node that has a reference and delete it.
+    // Assert that while an entity reference field is not composite,
+    // deleting a node will not delete any entities that it may be
+    // referencing.
+    // Create a node that references the first node
+    // and delete it right after.
     $values = [
-      'type' => 'test_ct',
-      'title' => 'Temporary entity',
-      'entity_reference_field' => [
+      'type' => $type->id(),
+      'title' => 'Referencing node',
+      $field_name => [
         'target_id' => $referenced_node->id(),
       ],
     ];
-    $temporary_node = $node_storage->create($values);
-    $temporary_node->save();
-    $temporary_node->delete();
+    if ($revisions) {
+      $values[$field_name]['target_revision_id'] = $referenced_node->getLoadedRevisionId();
+    }
+    $referencing_node = $node_storage->create($values);
+    $referencing_node->save();
+    $referencing_node->delete();
 
     // Reload the referenced node and assert it was not deleted because
-    // the field is not composite yet.
+    // the entity reference field is not composite yet.
     $node_storage->resetCache();
     $referenced_node = $node_storage->load($referenced_node->id());
     $this->assertNotEmpty($referenced_node);
 
-    // Update the field configuration to be composite.
+    // Assert that while an entity reference field is composite,
+    // deleting a node will not delete an entity it is referencing
+    // if another entity also references the same entity.
+    // Update the entity reference field configuration to be composite.
     $entity_reference_field->setThirdPartySetting('oe_content', 'composite', TRUE);
     $entity_reference_field->save();
 
-    // Create a node to keep the reference.
+    // Create a node that references the first one.
     $values = [
-      'type' => 'test_ct',
-      'title' => 'Referencing entity',
-      'entity_reference_field' => [
+      'type' => $type->id(),
+      'title' => 'Referencing node one',
+      $field_name => [
         'target_id' => $referenced_node->id(),
       ],
     ];
-    $referencing_node = $node_storage->create($values);
-    $referencing_node->save();
+    if ($revisions) {
+      $values[$field_name]['target_revision_id'] = $referenced_node->getLoadedRevisionId();
+    }
+    $referencing_node_one = $node_storage->create($values);
+    $referencing_node_one->save();
 
-    // Create a node that has a reference and delete it.
+    // Create a second node that that also references the first one
+    // and delete it right after.
     $values = [
-      'type' => 'test_ct',
-      'title' => 'Temporary entity',
-      'entity_reference_field' => [
+      'type' => $type->id(),
+      'title' => 'Referencing node two',
+      $field_name => [
         'target_id' => $referenced_node->id(),
       ],
     ];
-    $temporary_node = $node_storage->create($values);
-    $temporary_node->save();
-    $temporary_node->delete();
+    if ($revisions) {
+      $values[$field_name]['target_revision_id'] = $referenced_node->getLoadedRevisionId();
+    }
+    $referencing_node_two = $node_storage->create($values);
+    $referencing_node_two->save();
+    $referencing_node_two->delete();
 
     // Reload the referenced node and assert it was not deleted because
-    // the field is still referenced by another node.
+    // it is still being referenced by the first referencing node.
     $node_storage->resetCache();
     $referenced_node = $node_storage->load($referenced_node->id());
     $this->assertNotEmpty($referenced_node);
 
-    // Update the referencing node to stop referencing the entity.
-    $referencing_node->entity_reference_field->target_id = '';
-    $referencing_node->save();
+    // Assert that while an entity reference field is composite,
+    // deleting a node will delete an entity it is referencing
+    // if it is not referenced by any other entity.
+    // Update the first referencing node to stop referencing the first node.
+    $referencing_node_one->{$field_name}->target_id = '';
+    if ($revisions) {
+      $referencing_node_one->{$field_name}->target_revision_id = '';
+    }
+    $referencing_node_one->save();
 
-    // Create a node that has a reference and delete it.
+    // Create a third referencing node that that references the first one
+    // and delete it right after.
     $values = [
-      'type' => 'test_ct',
-      'title' => 'Temporary entity',
-      'entity_reference_field' => [
+      'type' => $type->id(),
+      'title' => 'Referencing node three',
+      $field_name => [
         'target_id' => $referenced_node->id(),
       ],
     ];
-    $temporary_node = $node_storage->create($values);
-    $temporary_node->save();
-    $temporary_node->delete();
+    if ($revisions) {
+      $values[$field_name]['target_revision_id'] = $referenced_node->getLoadedRevisionId();
+    }
+    $referencing_node_two_three = $node_storage->create($values);
+    $referencing_node_two_three->save();
+    $referencing_node_two_three->delete();
 
     // Reload the referenced node and assert it has been deleted because
-    // there are no more entities referencing it.
+    // there are no more nodes referencing it.
     $node_storage->resetCache();
     $referenced_node = $node_storage->load($referenced_node->id());
     $this->assertEmpty($referenced_node);

--- a/tests/Kernel/CompositeFieldsTest.php
+++ b/tests/Kernel/CompositeFieldsTest.php
@@ -33,7 +33,6 @@ class CompositeFieldsTest extends RdfKernelTestBase {
   protected function setUp(): void {
     parent::setUp();
 
-    $this->installSchema('user', 'users_data');
     $this->installSchema('node', 'node_access');
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');

--- a/tests/Kernel/CompositeFieldsTest.php
+++ b/tests/Kernel/CompositeFieldsTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_content\Kernel;
+
+use Drupal\Tests\rdf_entity\Kernel\RdfKernelTestBase;
+
+/**
+ * Tests composite reference fields.
+ */
+class CompositeFieldsTest extends RdfKernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'field',
+    'link',
+    'node',
+    'oe_content',
+    'rdf_skos',
+    'system',
+    'text',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installSchema('user', 'users_data');
+    $this->installSchema('node', 'node_access');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installConfig(['field', 'node']);
+    module_load_include('install', 'oe_content');
+    oe_content_install();
+  }
+
+  /**
+   * Test the defined fields.
+   */
+  public function testBaseStorage(): void {
+    $entity_type_manager = \Drupal::entityTypeManager();
+    // Create a content type.
+    $type = $entity_type_manager->getStorage('node_type')->create(['name' => 'Test content type', 'type' => 'test_ct']);
+    $type->save();
+
+    // Create an entity reference field.
+    $entity_type_manager->getStorage('field_storage_config')->create([
+      'entity_type' => 'node',
+      'field_name' => 'entity_reference_field',
+      'type' => 'entity_reference',
+      'cardinality' => 1,
+    ])->save();
+    /** @var \Drupal\field\FieldConfigInterface $entity_reference_field */
+    $entity_reference_field = $entity_type_manager->getStorage('field_config')->create([
+      'entity_type' => 'node',
+      'field_name' => 'entity_reference_field',
+      'bundle' => 'test_ct',
+      'label' => 'Entity reference field',
+      'translatable' => FALSE,
+      'settings' => [
+        'handler' => 'default:node',
+        'handler_settings' => [
+          'target_bundles' => [
+            'test_ct' => 'test_ct',
+          ],
+        ],
+      ],
+    ]);
+    $entity_reference_field->setThirdPartySetting('oe_content', 'composite', FALSE);
+    $entity_reference_field->save();
+
+    $node_storage = $entity_type_manager->getStorage('node');
+    // Create an entity to be referenced.
+    $values = [
+      'type' => 'test_ct',
+      'title' => 'Referenced entity',
+    ];
+    $referenced_node = $node_storage->create($values);
+    $referenced_node->save();
+
+    // Create a node that has a reference and delete it.
+    $values = [
+      'type' => 'test_ct',
+      'title' => 'Temporary entity',
+      'entity_reference_field' => [
+        'target_id' => $referenced_node->id(),
+      ],
+    ];
+    $temporary_node = $node_storage->create($values);
+    $temporary_node->save();
+    $temporary_node->delete();
+
+    // Reload the referenced node and assert it was not deleted because
+    // the field is not composite yet.
+    $node_storage->resetCache();
+    $referenced_node = $node_storage->load($referenced_node->id());
+    $this->assertNotEmpty($referenced_node);
+
+    // Update the field configuration to be composite.
+    $entity_reference_field->setThirdPartySetting('oe_content', 'composite', TRUE);
+    $entity_reference_field->save();
+
+    // Create a node to keep the reference.
+    $values = [
+      'type' => 'test_ct',
+      'title' => 'Referencing entity',
+      'entity_reference_field' => [
+        'target_id' => $referenced_node->id(),
+      ],
+    ];
+    $referencing_node = $node_storage->create($values);
+    $referencing_node->save();
+
+    // Create a node that has a reference and delete it.
+    $values = [
+      'type' => 'test_ct',
+      'title' => 'Temporary entity',
+      'entity_reference_field' => [
+        'target_id' => $referenced_node->id(),
+      ],
+    ];
+    $temporary_node = $node_storage->create($values);
+    $temporary_node->save();
+    $temporary_node->delete();
+
+    // Reload the referenced node and assert it was not deleted because
+    // the field is still referenced by another node.
+    $node_storage->resetCache();
+    $referenced_node = $node_storage->load($referenced_node->id());
+    $this->assertNotEmpty($referenced_node);
+
+    // Update the referencing node to stop referencing the entity.
+    $referencing_node->entity_reference_field->target_id = '';
+    $referencing_node->save();
+
+    // Create a node that has a reference and delete it.
+    $values = [
+      'type' => 'test_ct',
+      'title' => 'Temporary entity',
+      'entity_reference_field' => [
+        'target_id' => $referenced_node->id(),
+      ],
+    ];
+    $temporary_node = $node_storage->create($values);
+    $temporary_node->save();
+    $temporary_node->delete();
+
+    // Reload the referenced node and assert it has been deleted because
+    // there are no more entities referencing it.
+    $node_storage->resetCache();
+    $referenced_node = $node_storage->load($referenced_node->id());
+    $this->assertEmpty($referenced_node);
+  }
+
+}

--- a/tests/Kernel/CompositeReferenceFieldsTest.php
+++ b/tests/Kernel/CompositeReferenceFieldsTest.php
@@ -10,7 +10,7 @@ use Drupal\Tests\rdf_entity\Kernel\RdfKernelTestBase;
 /**
  * Tests composite reference fields.
  */
-class CompositeFieldsTest extends RdfKernelTestBase {
+class CompositeReferenceFieldsTest extends RdfKernelTestBase {
 
   use CompositeReferenceTestTrait;
 
@@ -46,7 +46,7 @@ class CompositeFieldsTest extends RdfKernelTestBase {
   /**
    * Test the composite option of entity reference fields.
    */
-  public function testCompositeOption(): void {
+  public function testCompositeReferenceFields(): void {
     $entity_type_manager = $this->container->get('entity_type.manager');
     // Create a test content type.
     $type = $entity_type_manager->getStorage('node_type')->create(['name' => 'Test content type', 'type' => 'test_ct']);
@@ -86,11 +86,9 @@ class CompositeFieldsTest extends RdfKernelTestBase {
       $referenced_node = $node_storage->create($values);
       $referenced_node->save();
 
-      // Assert that while an entity reference field is not composite,
-      // deleting a node will not delete any entities that it may be
-      // referencing.
-      // Create a node that references the first node
-      // and delete it right after.
+      // Assert that while an entity reference field is not composite, deleting
+      // a node will not delete any entities that it may be referencing.
+      // Create a node that references the first node and delete it right after.
       $values = [
         'type' => $type->id(),
         'title' => 'Referencing node',
@@ -105,15 +103,15 @@ class CompositeFieldsTest extends RdfKernelTestBase {
       $referencing_node->save();
       $referencing_node->delete();
 
-      // Reload the referenced node and assert it was not deleted because
-      // the entity reference field is not composite yet.
+      // Reload the referenced node and assert it was not deleted because the
+      // entity reference field is not composite yet.
       $node_storage->resetCache();
       $referenced_node = $node_storage->load($referenced_node->id());
       $this->assertNotEmpty($referenced_node);
 
-      // Assert that while an entity reference field is composite,
-      // deleting a node will not delete an entity it is referencing
-      // if another entity also references the same entity.
+      // Assert that while an entity reference field is composite, deleting a
+      // node will not delete an entity it is referencing if another entity also
+      // references the same entity.
       // Update the entity reference field configuration to be composite.
       $entity_reference_field->setThirdPartySetting('oe_content', 'composite', TRUE);
       $entity_reference_field->save();
@@ -132,8 +130,8 @@ class CompositeFieldsTest extends RdfKernelTestBase {
       $referencing_node_one = $node_storage->create($values);
       $referencing_node_one->save();
 
-      // Create a second node that that also references the first one
-      // and delete it right after.
+      // Create a second node that that also references the first one and delete
+      // it right after.
       $values = [
         'type' => $type->id(),
         'title' => 'Referencing node two',
@@ -148,15 +146,15 @@ class CompositeFieldsTest extends RdfKernelTestBase {
       $referencing_node_two->save();
       $referencing_node_two->delete();
 
-      // Reload the referenced node and assert it was not deleted because
-      // it is still being referenced by the first referencing node.
+      // Reload the referenced node and assert it was not deleted because it is
+      // still being referenced by the first referencing node.
       $node_storage->resetCache();
       $referenced_node = $node_storage->load($referenced_node->id());
       $this->assertNotEmpty($referenced_node);
 
-      // Assert that while an entity reference field is composite,
-      // deleting a node will delete an entity it is referencing
-      // if it is not referenced by any other entity.
+      // Assert that while an entity reference field is composite, deleting a
+      // node will delete an entity it is referencing if it is not referenced by
+      // any other entity.
       // Update the first referencing node to stop referencing the first node.
       $referencing_node_one->{$field_definition['field_name']}->target_id = '';
       if ($field_definition['revisions']) {
@@ -164,8 +162,8 @@ class CompositeFieldsTest extends RdfKernelTestBase {
       }
       $referencing_node_one->save();
 
-      // Create a third referencing node that that references the first one
-      // and delete it right after.
+      // Create a third referencing node that that references the first one and
+      // delete it right after.
       $values = [
         'type' => $type->id(),
         'title' => 'Referencing node three',
@@ -180,8 +178,8 @@ class CompositeFieldsTest extends RdfKernelTestBase {
       $referencing_node_two_three->save();
       $referencing_node_two_three->delete();
 
-      // Reload the referenced node and assert it has been deleted because
-      // there are no more nodes referencing it.
+      // Reload the referenced node and assert it has been deleted because there
+      // are no more nodes referencing it.
       $node_storage->resetCache();
       $referenced_node = $node_storage->load($referenced_node->id());
       $this->assertEmpty($referenced_node);

--- a/tests/Traits/CompositeReferenceTestTrait.php
+++ b/tests/Traits/CompositeReferenceTestTrait.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_content\Traits;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\FieldConfigInterface;
+
+/**
+ * Provides common functionality for the composite reference test classes.
+ */
+trait CompositeReferenceTestTrait {
+
+  /**
+   * Creates an entity reference field on the specified bundle.
+   *
+   * @param string $entity_type
+   *   The type of entity the field will be attached to.
+   * @param string $bundle
+   *   The bundle name of the entity the field will be attached to.
+   * @param string $field_name
+   *   The name of the field; if it already exists,
+   *   a new instance of the existing field will be created.
+   * @param string $field_label
+   *   The label of the field.
+   * @param string $target_entity_type
+   *   The type of the referenced entity.
+   * @param string $selection_handler
+   *   The selection handler used by this field.
+   * @param array $selection_handler_settings
+   *   An array of settings supported by the selection handler specified above.
+   *   (e.g. 'target_bundles', 'sort', 'auto_create', etc).
+   * @param int $cardinality
+   *   The cardinality of the field.
+   * @param bool $revision
+   *   Whether to make it a entity reference revision field or not.
+   *
+   * @return \Drupal\field\FieldConfigInterface
+   *   The field_config for the newly created field.
+   */
+  protected function createEntityReferenceField(string $entity_type, string $bundle, string $field_name, string $field_label, string $target_entity_type, string $selection_handler = 'default', array $selection_handler_settings = [], int $cardinality = 1, bool $revision = FALSE): FieldConfigInterface {
+    // Look for or add the specified field to the requested entity bundle.
+    if (!FieldStorageConfig::loadByName($entity_type, $field_name)) {
+      /** @var \Drupal\field\FieldStorageConfigInterface $reference_field_storage */
+      $reference_field_storage = FieldStorageConfig::create([
+        'field_name' => $field_name,
+        'type' => 'entity_reference',
+        'entity_type' => $entity_type,
+        'cardinality' => $cardinality,
+        'settings' => [
+          'target_type' => $target_entity_type,
+        ],
+      ]);
+      if ($revision) {
+        $reference_field_storage->set('type', 'entity_reference_revisions');
+      }
+      $reference_field_storage->save();
+    }
+    if ($reference_field = FieldConfig::loadByName($entity_type, $bundle, $field_name)) {
+      return $reference_field;
+    }
+    $reference_field = FieldConfig::create([
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'bundle' => $bundle,
+      'label' => $field_label,
+      'settings' => [
+        'handler' => $selection_handler,
+        'handler_settings' => $selection_handler_settings,
+      ],
+    ]);
+    $reference_field->save();
+    return $reference_field;
+  }
+
+  /**
+   * Entity reference field definition provider.
+   *
+   * @return array
+   *   An array of entity reference definitions.
+   */
+  public function compositeFieldDefinitions(): array {
+    return [
+      [
+        'entity_reference_field',
+        'Entity reference field',
+        FALSE,
+      ],
+      [
+        'entity_reference_revisions_field',
+        'Entity reference revisions field',
+        TRUE,
+      ],
+    ];
+  }
+
+}

--- a/tests/Traits/CompositeReferenceTestTrait.php
+++ b/tests/Traits/CompositeReferenceTestTrait.php
@@ -72,28 +72,8 @@ trait CompositeReferenceTestTrait {
       ],
     ]);
     $reference_field->save();
-    return $reference_field;
-  }
 
-  /**
-   * Entity reference field definition provider.
-   *
-   * @return array
-   *   An array of entity reference definitions.
-   */
-  public function compositeFieldDefinitions(): array {
-    return [
-      [
-        'entity_reference_field',
-        'Entity reference field',
-        FALSE,
-      ],
-      [
-        'entity_reference_revisions_field',
-        'Entity reference revisions field',
-        TRUE,
-      ],
-    ];
+    return $reference_field;
   }
 
 }


### PR DESCRIPTION
## OPENEUROPA-3135

### Description

Add the possibility to flag entity reference fields as composite. Compositte fields will delete the referenced entity if no other entity is referencing it.
### Change log

- Added: Composite entity reference fields.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

