### PR TITLE
OPENEUROPA-3135: Add composite_reference module and configure event to use it.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/linkit": "~5.0-beta8",
         "drupal/maxlength": "~1.0@beta",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",
-        "openeuropa/rdf_skos": "~0.7",
+        "openeuropa/rdf_skos": "~0.8",
         "openeuropa/oe_media": "^1.4",
         "php": ">=7.2"
     },
@@ -18,6 +18,7 @@
         "composer/installers": "~1.5",
         "drupal-composer/drupal-scaffold": "~2.5.2",
         "drupal/address": "~1.7",
+        "drupal/composite_reference": "1.x-dev",
         "drupal/config_devel": "~1.2",
         "drupal/datetime_testing": "1.x-dev",
         "drupal/drupal-extension": "~4.0",
@@ -77,9 +78,6 @@
         "patches": {
             "drupal/field_group": {
                 "https://www.drupal.org/project/field_group/issues/2787179#comment-13467953": "https://www.drupal.org/files/issues/2020-02-17/2787179-highlight-html5-validation-45.patch"
-            },
-            "openeuropa/rdf_skos": {
-                "latest-master": "https://github.com/openeuropa/rdf_skos/compare/0.7.0...master.diff"
             }
         }
     },

--- a/modules/oe_content_event/README.md
+++ b/modules/oe_content_event/README.md
@@ -9,6 +9,7 @@ Before enabling this module, make sure that the following modules are present in
 
 ```json
 "require": {
+    "drupal/composite_reference": "1.x-dev",
     "drupal/entity_reference_revisions": "~1.3",
     "drupal/field_group": "~3.0",
     "drupal/inline_entity_form": "~1.0-rc3",

--- a/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_contact.yml
+++ b/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_contact.yml
@@ -8,6 +8,10 @@ dependencies:
     - oe_content_entity_contact.oe_contact_type.oe_press
   module:
     - entity_reference_revisions
+    - oe_content
+third_party_settings:
+  composite_reference:
+    composite: true
 id: node.oe_event.oe_event_contact
 field_name: oe_event_contact
 entity_type: node

--- a/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_venue.yml
+++ b/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_venue.yml
@@ -7,6 +7,10 @@ dependencies:
     - oe_content_entity_venue.oe_venue_type.oe_default
   module:
     - entity_reference_revisions
+    - oe_content
+third_party_settings:
+  composite_reference:
+    composite: true
 id: node.oe_event.oe_event_venue
 field_name: oe_event_venue
 entity_type: node

--- a/modules/oe_content_event/oe_content_event.info.yml
+++ b/modules/oe_content_event/oe_content_event.info.yml
@@ -5,6 +5,7 @@ type: module
 core: 8.x
 
 dependencies:
+  - drupal:composite_reference
   - oe_content:oe_content
   - oe_content:oe_content_entity_contact
   - oe_content:oe_content_entity_contact

--- a/modules/oe_content_event/oe_content_event.post_update.php
+++ b/modules/oe_content_event/oe_content_event.post_update.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for OpenEuropa Event Content module.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\field\Entity\FieldConfig;
+
+/**
+ * Make the Event venue and contact fields composite.
+ */
+function oe_content_event_post_update_00001(array &$sandbox) {
+  \Drupal::service('module_installer')->install(['composite_reference']);
+
+  $fields = [
+    'node.oe_event.oe_event_venue',
+    'node.oe_event.oe_event_contact',
+  ];
+  foreach ($fields as $field) {
+    $field_config = FieldConfig::load($field);
+    $field_config->setThirdPartySetting('composite_reference', 'composite', TRUE);
+    $field_config->save();
+  }
+}

--- a/modules/oe_content_event/tests/src/Kernel/EventKernelTestBase.php
+++ b/modules/oe_content_event/tests/src/Kernel/EventKernelTestBase.php
@@ -41,6 +41,7 @@ abstract class EventKernelTestBase extends RdfKernelTestBase {
     'text',
     'typed_link',
     'user',
+    'composite_reference',
   ];
 
   /**


### PR DESCRIPTION
## OPENEUROPA-3135

### Description

Add composite_reference module and configure event to use it.

### Change log

- Added: Composite reference module.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

