### PR TITLE
OPENEUROPA-3135: Use alpha1 release for composite_reference.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "composer/installers": "~1.5",
         "drupal-composer/drupal-scaffold": "~2.5.2",
         "drupal/address": "~1.7",
-        "drupal/composite_reference": "1.x-dev",
+        "drupal/composite_reference": "~1.0-alpha1",
         "drupal/config_devel": "~1.2",
         "drupal/datetime_testing": "1.x-dev",
         "drupal/drupal-extension": "~4.0",

--- a/modules/oe_content_event/README.md
+++ b/modules/oe_content_event/README.md
@@ -9,7 +9,7 @@ Before enabling this module, make sure that the following modules are present in
 
 ```json
 "require": {
-    "drupal/composite_reference": "1.x-dev",
+    "drupal/composite_reference": "~1.0-alpha1",
     "drupal/entity_reference_revisions": "~1.3",
     "drupal/field_group": "~3.0",
     "drupal/inline_entity_form": "~1.0-rc3",


### PR DESCRIPTION
## OPENEUROPA-3135

### Description

Use alpha1 release for composite_reference.

### Change log

- Added:
- Changed: Use alpha1 release for composite_reference.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

