### PR TITLE
OPENEUROPA-3371: Change getRevisionField() to getReferenceField() and…

### DIFF
--- a/tests/Behat/Content/Node/EventContentContext.php
+++ b/tests/Behat/Content/Node/EventContentContext.php
@@ -80,7 +80,7 @@ class EventContentContext extends RawDrupalContext {
           break;
 
         case 'Featured media':
-          $fields = $this->getRevisionField($mapping[$key], 'media', $value);
+          $fields = $this->getReferenceField($mapping[$key], 'media', $value);
           $scope->addFields($fields)->removeField($key);
           break;
 
@@ -93,7 +93,7 @@ class EventContentContext extends RawDrupalContext {
         case 'Type':
         case 'Languages':
         case 'Internal organiser':
-          $fields = $this->getRevisionField($mapping[$key], 'skos_concept', $value);
+          $fields = $this->getReferenceField($mapping[$key], 'skos_concept', $value);
           $scope->addFields($fields)->removeField($key);
           break;
 

--- a/tests/Traits/EntityReferenceTrait.php
+++ b/tests/Traits/EntityReferenceTrait.php
@@ -5,15 +5,15 @@ declare(strict_types = 1);
 namespace Drupal\Tests\oe_content\Traits;
 
 /**
- * Helper trait to handle entity revision fields in Behat tests.
+ * Helper trait to handle entity reference fields in Behat tests.
  */
 trait EntityReferenceTrait {
 
   /**
-   * Get revision field in a multi-value, parsable format.
+   * Get reference field in a multi-value, parsable format.
    *
    * @param string $field_name
-   *   Revision field name.
+   *   Reference field name.
    * @param string $entity_type
    *   Entity type machine name.
    * @param string $labels
@@ -22,7 +22,7 @@ trait EntityReferenceTrait {
    * @return array
    *   Expanded field name with comma separated list of target IDs.
    */
-  protected function getRevisionField(string $field_name, string $entity_type, string $labels): array {
+  protected function getReferenceField(string $field_name, string $entity_type, string $labels): array {
     // Transform titles to ids and maintain the comma separated format.
     $items = explode(',', $labels);
     $items = array_map('trim', $items);


### PR DESCRIPTION
## OPENEUROPA-3371

### Description

Change `\Drupal\Tests\oe_content\Traits\EntityReferenceTrait`  method "getRevisionField()" to `getReferenceField()` and update comments.

### Change log


- Changed: Change getRevisionField() to getReferenceField()


