### PR TITLE
EWPP-58 #3: Add common 'Card' view_mode.

### DIFF
--- a/config/install/core.entity_view_mode.node.card.yml
+++ b/config/install/core.entity_view_mode.node.card.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.card
+label: Card
+targetEntityType: node
+cache: true


### PR DESCRIPTION
### Description

Add common view_mode **Card** to be used by Content Types (see their Specifications)
- [Call for Tenders](https://webgate.ec.europa.eu/fpfis/wikis/pages/viewpage.action?pageId=437857073#CallforTendersContentTypeSpecification-Version1.0.0-Carddisplaymode)
- [Call for Proposals](https://webgate.ec.europa.eu/fpfis/wikis/display/EWPP/Call+for+Proposals+Content+Type+Specification+-+Version+1.0.0#CallforProposalsContentTypeSpecification-Version1.0.0-Carddisplaymode)
- [Project](https://webgate.ec.europa.eu/fpfis/wikis/pages/viewpage.action?pageId=388531445#ProjectContentTypeSpecification-Version1.0.1-Card)