### PR TITLE
OPENEUROPA-3380: Use base hook for templates of corporate entities.

### DIFF
--- a/modules/oe_content_entity/modules/oe_content_entity_contact/oe_content_entity_contact.module
+++ b/modules/oe_content_entity/modules/oe_content_entity_contact/oe_content_entity_contact.module
@@ -14,9 +14,7 @@ function oe_content_entity_contact_theme() {
   return [
     'oe_contact' => [
       'render element' => 'elements',
-      'preprocess functions' => [
-        'oe_content_entity_default_preprocess',
-      ],
+      'base hook' => 'oe_content_entity',
     ],
   ];
 }

--- a/modules/oe_content_entity/modules/oe_content_entity_organisation/oe_content_entity_organisation.module
+++ b/modules/oe_content_entity/modules/oe_content_entity_organisation/oe_content_entity_organisation.module
@@ -14,9 +14,7 @@ function oe_content_entity_organisation_theme() {
   return [
     'oe_organisation' => [
       'render element' => 'elements',
-      'preprocess functions' => [
-        'oe_content_entity_default_preprocess',
-      ],
+      'base hook' => 'oe_content_entity',
     ],
   ];
 }

--- a/modules/oe_content_entity/modules/oe_content_entity_venue/oe_content_entity_venue.module
+++ b/modules/oe_content_entity/modules/oe_content_entity_venue/oe_content_entity_venue.module
@@ -14,9 +14,7 @@ function oe_content_entity_venue_theme() {
   return [
     'oe_venue' => [
       'render element' => 'elements',
-      'preprocess functions' => [
-        'oe_content_entity_default_preprocess',
-      ],
+      'base hook' => 'oe_content_entity',
     ],
   ];
 }

--- a/modules/oe_content_entity/oe_content_entity.module
+++ b/modules/oe_content_entity/oe_content_entity.module
@@ -10,20 +10,27 @@ declare(strict_types = 1);
 use Drupal\Core\Render\Element;
 
 /**
+ * Implements hook_theme().
+ */
+function oe_content_entity_theme() {
+  return [
+    'oe_content_entity' => [
+      'render element' => 'elements',
+    ],
+  ];
+}
+
+/**
  * Default preprocess function to be ran for all corporate entities.
  *
  * This preprocess sets default values to be passed to the main entity
- * render template. Add this to 'preprocess functions' in
- * oe_content_entity_NAME_theme() when defining a new corporate content
- * entity type.
+ * render template.
  *
  * @param array $variables
  *   Render variables.
- * @param string $hook
- *   Hook name, in this case the entity type ID itself.
  */
-function oe_content_entity_default_preprocess(array &$variables, $hook) {
-  $variables['entity'] = $variables['elements']["#{$hook}"];
+function template_preprocess_oe_content_entity(array &$variables) {
+  $variables['entity'] = $variables['elements']["#{$variables['theme_hook_original']}"];
   $variables['view_mode'] = $variables['elements']['#view_mode'];
   $variables['label'] = $variables['entity']->label();
 

--- a/modules/oe_content_entity/src/Entity/CorporateEntityInterface.php
+++ b/modules/oe_content_entity/src/Entity/CorporateEntityInterface.php
@@ -16,6 +16,16 @@ use Drupal\Core\Entity\RevisionLogInterface;
 interface CorporateEntityInterface extends EntityChangedInterface, EntityPublishedInterface, RevisionLogInterface {
 
   /**
+   * Denotes that the entity is not published.
+   */
+  const NOT_PUBLISHED = 0;
+
+  /**
+   * Denotes that the entity is published.
+   */
+  const PUBLISHED = 1;
+
+  /**
    * Gets the corporate content entity type.
    *
    * @return string


### PR DESCRIPTION
## OPENEUROPA-3380

Change log

Added:
* Constants PUBLISHED, NOT_PUBLISHED to CorporateEntityInterface.

Changed:
* Corporate entities use template oe_content_entity as a base.

