### PR TITLE
EWPP-94: Refactor the PURL module to allow for other entity types

### DIFF
--- a/modules/oe_content_persistent/config/install/oe_content_persistent.settings.yml
+++ b/modules/oe_content_persistent/config/install/oe_content_persistent.settings.yml
@@ -1,2 +1,4 @@
 langcode: en
 base_url: 'https://data.ec.europa.eu/ewp/'
+supported_entity_types:
+  node: node

--- a/modules/oe_content_persistent/config/schema/oe_content_persistent.schema.yml
+++ b/modules/oe_content_persistent/config/schema/oe_content_persistent.schema.yml
@@ -5,3 +5,9 @@ oe_content_persistent.settings:
     base_url:
       type: uri
       label: 'Inter institutional base path'
+    supported_entity_types:
+      type: sequence
+      label: 'Supported entity types'
+      sequence:
+        type: string
+        label: 'Entity type ID'

--- a/modules/oe_content_persistent/oe_content_persistent.post_update.php
+++ b/modules/oe_content_persistent/oe_content_persistent.post_update.php
@@ -11,7 +11,12 @@ declare(strict_types = 1);
  * Update PURL configuration.
  */
 function oe_content_persistent_post_update_00001(): void {
+  $supported_entity_types = \Drupal::getContainer()->getParameter('oe_content_persistent.supported_entity_types');
+  if (empty($supported_entity_types)) {
+    $supported_entity_types = ['node'];
+  }
+  $supported_entity_types = array_combine($supported_entity_types, $supported_entity_types);
   $purl_config = \Drupal::configFactory()->getEditable('oe_content_persistent.settings');
-  $purl_config->set('supported_entity_types', ['node' => 'node']);
+  $purl_config->set('supported_entity_types', $supported_entity_types);
   $purl_config->save();
 }

--- a/modules/oe_content_persistent/oe_content_persistent.post_update.php
+++ b/modules/oe_content_persistent/oe_content_persistent.post_update.php
@@ -11,7 +11,9 @@ declare(strict_types = 1);
  * Update PURL configuration.
  */
 function oe_content_persistent_post_update_00001(): void {
-  $supported_entity_types = \Drupal::getContainer()->getParameter('oe_content_persistent.supported_entity_types');
+  if (\Drupal::getContainer()->hasParameter('oe_content_persistent.supported_entity_types')) {
+    $supported_entity_types = \Drupal::getContainer()->getParameter('oe_content_persistent.supported_entity_types');
+  }
   if (empty($supported_entity_types)) {
     $supported_entity_types = ['node'];
   }

--- a/modules/oe_content_persistent/oe_content_persistent.post_update.php
+++ b/modules/oe_content_persistent/oe_content_persistent.post_update.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Post update functions for OpenEuropa Content module.
+ * Post update functions for OpenEuropa Content Persistent module.
  */
 
 declare(strict_types = 1);

--- a/modules/oe_content_persistent/oe_content_persistent.post_update.php
+++ b/modules/oe_content_persistent/oe_content_persistent.post_update.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for OpenEuropa Content module.
+ */
+
+declare(strict_types = 1);
+
+/**
+ * Update PURL configuration.
+ */
+function oe_content_persistent_post_update_00001(): void {
+  $purl_config = \Drupal::configFactory()->getEditable('oe_content_persistent.settings');
+  $purl_config->set('supported_entity_types', ['node' => 'node']);
+  $purl_config->save();
+}

--- a/modules/oe_content_persistent/oe_content_persistent.services.yml
+++ b/modules/oe_content_persistent/oe_content_persistent.services.yml
@@ -1,10 +1,7 @@
-parameters:
-  oe_content_persistent.supported_entity_types:
-    - node
 services:
   oe_content_persistent.resolver:
     class: \Drupal\oe_content_persistent\ContentUuidResolver
-    arguments: ['@entity_type.manager', '%oe_content_persistent.supported_entity_types%']
+    arguments: ['@entity_type.manager', '@config.factory']
 
   oe_content_persistent.redirect_subscriber:
     class: \Drupal\oe_content_persistent\EventSubscriber\PersistentUrlRedirectSubscriber

--- a/modules/oe_content_persistent/oe_content_persistent.services.yml
+++ b/modules/oe_content_persistent/oe_content_persistent.services.yml
@@ -1,10 +1,13 @@
 services:
-  oe_content_persistent.resolver:
+  oe_content_persistent.uuid_resolver:
     class: \Drupal\oe_content_persistent\ContentUuidResolver
     arguments: ['@entity_type.manager', '@config.factory']
+  oe_content_persistent.url_resolver:
+    class: \Drupal\oe_content_persistent\ContentUrlResolver
+    arguments: ['@event_dispatcher']
 
   oe_content_persistent.redirect_subscriber:
     class: \Drupal\oe_content_persistent\EventSubscriber\PersistentUrlRedirectSubscriber
-    arguments: ['@oe_content_persistent.resolver']
+    arguments: ['@oe_content_persistent.uuid_resolver']
     tags:
       - { name: event_subscriber }

--- a/modules/oe_content_persistent/src/ContentUrlResolver.php
+++ b/modules/oe_content_persistent/src/ContentUrlResolver.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_content_persistent;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Url;
+use Drupal\oe_content_persistent\Event\PersistentUrlResolverEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Default implementation of a Content URL resolver.
+ */
+class ContentUrlResolver implements ContentUrlResolverInterface {
+
+  /**
+   * Static cache of UUID lookups, per language.
+   *
+   * @var array
+   */
+  protected $lookupMap = [];
+
+  /**
+   * The entity dispatcher.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  protected $eventDispatcher;
+
+  /**
+   * Constructs a ContentUuidResolver.
+   *
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
+   *   The event dispatcher.
+   */
+  public function __construct(EventDispatcherInterface $event_dispatcher) {
+    $this->eventDispatcher = $event_dispatcher;
+  }
+
+  /**
+   * Resets the static cache.
+   */
+  public function resetStaticCache(): void {
+    $this->lookupMap = [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveUrl(ContentEntityInterface $entity): Url {
+    $langcode = $langcode ?? LanguageInterface::LANGCODE_DEFAULT;
+
+    // Try the static cache first.
+    if (isset($this->lookupMap[$entity->uuid()]) && array_key_exists($langcode, $this->lookupMap[$entity->uuid()])) {
+      return $this->lookupMap[$entity->uuid()][$langcode];
+    }
+    // Not all entity types will need to be linked to their canonical URLs,
+    // so we dispatch an event to allow to modify the resulting URL.
+    $event = new PersistentUrlResolverEvent($entity);
+    $this->eventDispatcher->dispatch(PersistentUrlResolverEvent::NAME, $event);
+    $url = $event->hasUrl() ? $event->getUrl() : $entity->toUrl();
+    $this->lookupMap[$entity->uuid()][$entity->language()->getId()] = $url;
+    return $url;
+  }
+
+}

--- a/modules/oe_content_persistent/src/ContentUrlResolver.php
+++ b/modules/oe_content_persistent/src/ContentUrlResolver.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace Drupal\oe_content_persistent;
 
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Url;
 use Drupal\oe_content_persistent\Event\PersistentUrlResolverEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -16,7 +15,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class ContentUrlResolver implements ContentUrlResolverInterface {
 
   /**
-   * Static cache of UUID lookups, per language.
+   * Static cache of resolved URLs, per language.
    *
    * @var array
    */
@@ -30,7 +29,7 @@ class ContentUrlResolver implements ContentUrlResolverInterface {
   protected $eventDispatcher;
 
   /**
-   * Constructs a ContentUuidResolver.
+   * Constructs a ContentUrlResolver.
    *
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *   The event dispatcher.
@@ -50,11 +49,12 @@ class ContentUrlResolver implements ContentUrlResolverInterface {
    * {@inheritdoc}
    */
   public function resolveUrl(ContentEntityInterface $entity): Url {
-    $langcode = $langcode ?? LanguageInterface::LANGCODE_DEFAULT;
+    $langcode = $entity->language()->getId();
+    $uuid = $entity->uuid();
 
     // Try the static cache first.
-    if (isset($this->lookupMap[$entity->uuid()]) && array_key_exists($langcode, $this->lookupMap[$entity->uuid()])) {
-      return $this->lookupMap[$entity->uuid()][$langcode];
+    if (isset($this->lookupMap[$uuid]) && array_key_exists($langcode, $this->lookupMap[$uuid])) {
+      return $this->lookupMap[$uuid][$langcode];
     }
     // Not all entity types will need to be linked to their canonical URLs,
     // so we dispatch an event to allow to modify the resulting URL.

--- a/modules/oe_content_persistent/src/ContentUrlResolverInterface.php
+++ b/modules/oe_content_persistent/src/ContentUrlResolverInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_content_persistent;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Url;
+
+/**
+ * Interface for services that resolve the URL of an entity.
+ */
+interface ContentUrlResolverInterface {
+
+  /**
+   * Resolve the URL of an entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   A content entity.
+   *
+   * @return \Drupal\Core\Url
+   *   The resolved URL.
+   */
+  public function resolveUrl(ContentEntityInterface $entity): Url;
+
+}

--- a/modules/oe_content_persistent/src/ContentUuidResolver.php
+++ b/modules/oe_content_persistent/src/ContentUuidResolver.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_content_persistent;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageInterface;
@@ -28,23 +29,23 @@ class ContentUuidResolver implements ContentUuidResolverInterface {
   protected $entityTypeManager;
 
   /**
-   * List of supported entity types.
+   * The config of PURL.
    *
-   * @var array
+   * @var \Drupal\Core\Config\ImmutableConfig
    */
-  protected $supportedEntityTypes;
+  protected $purlConfig;
 
   /**
    * Constructs a ContentUuidResolver.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
-   * @param array $supported_entity_types
-   *   List of supported entity types.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The configuration factory.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, array $supported_entity_types = []) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory) {
     $this->entityTypeManager = $entity_type_manager;
-    $this->supportedEntityTypes = $supported_entity_types;
+    $this->purlConfig = $config_factory->get('oe_content_persistent.settings');
   }
 
   /**
@@ -65,9 +66,9 @@ class ContentUuidResolver implements ContentUuidResolverInterface {
       return $this->lookupMap[$uuid][$langcode];
     }
 
-    // Loop through the available storages and load the entity from the first
+    // Loop through the supported storages and load the entity from the first
     // storage we find it in.
-    foreach ($this->supportedEntityTypes as $entity_type) {
+    foreach ($this->purlConfig->get('supported_entity_types') as $entity_type) {
       $storage = $this->entityTypeManager->getStorage($entity_type);
       $entities = $storage->loadByProperties(['uuid' => $uuid]);
       if (empty($entities)) {

--- a/modules/oe_content_persistent/src/Controller/PersistentUrlController.php
+++ b/modules/oe_content_persistent/src/Controller/PersistentUrlController.php
@@ -6,9 +6,11 @@ namespace Drupal\oe_content_persistent\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\Core\Entity\TranslatableInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\oe_content_persistent\ContentUuidResolverInterface;
+use Drupal\oe_content_persistent\Event\PersistentUrlResolverEvent;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -16,6 +18,13 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  * Controller that redirects to an entity based on its UUID.
  */
 class PersistentUrlController extends ControllerBase implements ContainerInjectionInterface {
+
+  /**
+   * The event dispatcher.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  protected $eventDispatcher;
 
   /**
    * The content UUID resolver.
@@ -27,10 +36,13 @@ class PersistentUrlController extends ControllerBase implements ContainerInjecti
   /**
    * PersistentUrlController constructor.
    *
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
+   *   The event dispatcher.
    * @param \Drupal\oe_content_persistent\ContentUuidResolverInterface $uuid_resolver
    *   The content UUID resolver.
    */
-  public function __construct(ContentUuidResolverInterface $uuid_resolver) {
+  public function __construct(EventDispatcherInterface $event_dispatcher, ContentUuidResolverInterface $uuid_resolver) {
+    $this->eventDispatcher = $event_dispatcher;
     $this->contentUuidResolver = $uuid_resolver;
   }
 
@@ -39,6 +51,7 @@ class PersistentUrlController extends ControllerBase implements ContainerInjecti
    */
   public static function create(ContainerInterface $container) {
     return new static(
+      $container->get('event_dispatcher'),
       $container->get('oe_content_persistent.resolver')
     );
   }
@@ -60,8 +73,14 @@ class PersistentUrlController extends ControllerBase implements ContainerInjecti
       // \Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber.
       // More information you could find in this article:
       // https://www.lullabot.com/articles/early-rendering-a-lesson-in-debugging-drupal-8
-      if ($entity instanceof TranslatableInterface) {
-        return new RedirectResponse($entity->toUrl()->toString(), 302, ['PURL' => '1']);
+      if ($entity instanceof EntityInterface) {
+
+        // Not all entity types will need to be linked to their canonical URLs,
+        // so we dispatch an event to allow to modify the resulting URL.
+        $event = new PersistentUrlResolverEvent($entity);
+        $this->eventDispatcher->dispatch(PersistentUrlResolverEvent::NAME, $event);
+        $url = is_null($event->getUrl()) ? $entity->toUrl() : $event->getUrl();
+        return new RedirectResponse($url->toString(), 302, ['PURL' => '1']);
       }
     }
 

--- a/modules/oe_content_persistent/src/Controller/PersistentUrlController.php
+++ b/modules/oe_content_persistent/src/Controller/PersistentUrlController.php
@@ -73,8 +73,6 @@ class PersistentUrlController extends ControllerBase implements ContainerInjecti
       // More information you could find in this article:
       // https://www.lullabot.com/articles/early-rendering-a-lesson-in-debugging-drupal-8
       if ($entity instanceof ContentEntityInterface) {
-        // Not all entity types will need to be linked to their
-        // canonical URLs so use the url resolver to get the final URL.
         $url = $this->contentUrlResolver->resolveUrl($entity);
         return new RedirectResponse($url->toString(), 302, ['PURL' => '1']);
       }

--- a/modules/oe_content_persistent/src/Controller/PersistentUrlController.php
+++ b/modules/oe_content_persistent/src/Controller/PersistentUrlController.php
@@ -74,7 +74,6 @@ class PersistentUrlController extends ControllerBase implements ContainerInjecti
       // More information you could find in this article:
       // https://www.lullabot.com/articles/early-rendering-a-lesson-in-debugging-drupal-8
       if ($entity instanceof EntityInterface) {
-
         // Not all entity types will need to be linked to their canonical URLs,
         // so we dispatch an event to allow to modify the resulting URL.
         $event = new PersistentUrlResolverEvent($entity);

--- a/modules/oe_content_persistent/src/Controller/PersistentUrlController.php
+++ b/modules/oe_content_persistent/src/Controller/PersistentUrlController.php
@@ -6,7 +6,7 @@ namespace Drupal\oe_content_persistent\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\oe_content_persistent\ContentUuidResolverInterface;
 use Drupal\oe_content_persistent\Event\PersistentUrlResolverEvent;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -73,7 +73,7 @@ class PersistentUrlController extends ControllerBase implements ContainerInjecti
       // \Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber.
       // More information you could find in this article:
       // https://www.lullabot.com/articles/early-rendering-a-lesson-in-debugging-drupal-8
-      if ($entity instanceof EntityInterface) {
+      if ($entity instanceof ContentEntityInterface) {
         // Not all entity types will need to be linked to their canonical URLs,
         // so we dispatch an event to allow to modify the resulting URL.
         $event = new PersistentUrlResolverEvent($entity);

--- a/modules/oe_content_persistent/src/Event/PersistentUrlResolverEvent.php
+++ b/modules/oe_content_persistent/src/Event/PersistentUrlResolverEvent.php
@@ -19,21 +19,21 @@ class PersistentUrlResolverEvent extends Event {
   const NAME = 'oe_content_persistent.event.persistent_url_resolver';
 
   /**
-   * The content entity whose URL we want to resolve.
+   * The entity whose URL we want to resolve.
    *
    * @var \Drupal\Core\Entity\EntityInterface
    */
   protected $entity;
 
   /**
-   * The resulting url.
+   * The resulting URL.
    *
    * @var \Drupal\Core\Url|null
    */
   protected $url = NULL;
 
   /**
-   * EntityValueResolverEvent constructor.
+   * PersistentUrlResolverEvent constructor.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The content entity.
@@ -53,20 +53,20 @@ class PersistentUrlResolverEvent extends Event {
   }
 
   /**
-   * Gets the url.
+   * Gets the URL.
    *
    * @return \Drupal\Core\Url|null
-   *   The resolved url.
+   *   The resolved URL.
    */
   public function getUrl(): ?Url {
     return $this->url;
   }
 
   /**
-   * Sets the url.
+   * Sets the URL.
    *
    * @param \Drupal\Core\Url $url
-   *   The resolved url.
+   *   The resolved URL.
    */
   public function setUrl(Url $url): void {
     $this->url = $url;

--- a/modules/oe_content_persistent/src/Event/PersistentUrlResolverEvent.php
+++ b/modules/oe_content_persistent/src/Event/PersistentUrlResolverEvent.php
@@ -28,9 +28,9 @@ class PersistentUrlResolverEvent extends Event {
   /**
    * The resulting URL.
    *
-   * @var \Drupal\Core\Url|null
+   * @var \Drupal\Core\Url
    */
-  protected $url = NULL;
+  protected $url;
 
   /**
    * PersistentUrlResolverEvent constructor.
@@ -53,12 +53,22 @@ class PersistentUrlResolverEvent extends Event {
   }
 
   /**
+   * Asserts whether a URL was set or not.
+   *
+   * @return bool
+   *   Whether the URL was set or not.
+   */
+  public function hasUrl(): bool {
+    return isset($this->url);
+  }
+
+  /**
    * Gets the URL.
    *
-   * @return \Drupal\Core\Url|null
+   * @return \Drupal\Core\Url
    *   The resolved URL.
    */
-  public function getUrl(): ?Url {
+  public function getUrl(): Url {
     return $this->url;
   }
 

--- a/modules/oe_content_persistent/src/Event/PersistentUrlResolverEvent.php
+++ b/modules/oe_content_persistent/src/Event/PersistentUrlResolverEvent.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_content_persistent\Event;
 
-use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Url;
 use Symfony\Component\EventDispatcher\Event;
 
@@ -16,12 +16,12 @@ class PersistentUrlResolverEvent extends Event {
   /**
    * The name of the event.
    */
-  const NAME = 'oe_content_persistent.event.persistent_url_resolver';
+  const NAME = 'oe_content_persistent.event.entity_url_resolver';
 
   /**
    * The entity whose URL we want to resolve.
    *
-   * @var \Drupal\Core\Entity\EntityInterface
+   * @var \Drupal\Core\Entity\ContentEntityInterface
    */
   protected $entity;
 
@@ -35,20 +35,20 @@ class PersistentUrlResolverEvent extends Event {
   /**
    * PersistentUrlResolverEvent constructor.
    *
-   * @param \Drupal\Core\Entity\EntityInterface $entity
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   The content entity.
    */
-  public function __construct(EntityInterface $entity) {
+  public function __construct(ContentEntityInterface $entity) {
     $this->entity = $entity;
   }
 
   /**
    * Returns the entity.
    *
-   * @return \Drupal\Core\Entity\EntityInterface
+   * @return \Drupal\Core\Entity\ContentEntityInterface
    *   The entity.
    */
-  public function getEntity(): EntityInterface {
+  public function getEntity(): ContentEntityInterface {
     return $this->entity;
   }
 

--- a/modules/oe_content_persistent/src/Event/PersistentUrlResolverEvent.php
+++ b/modules/oe_content_persistent/src/Event/PersistentUrlResolverEvent.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_content_persistent\Event;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Url;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event used to resolve the URL of an entity from its PURL.
+ */
+class PersistentUrlResolverEvent extends Event {
+
+  /**
+   * The name of the event.
+   */
+  const NAME = 'oe_content_persistent.event.persistent_url_resolver';
+
+  /**
+   * The content entity whose URL we want to resolve.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected $entity;
+
+  /**
+   * The resulting url.
+   *
+   * @var \Drupal\Core\Url|null
+   */
+  protected $url = NULL;
+
+  /**
+   * EntityValueResolverEvent constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The content entity.
+   */
+  public function __construct(EntityInterface $entity) {
+    $this->entity = $entity;
+  }
+
+  /**
+   * Returns the entity.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   The entity.
+   */
+  public function getEntity(): EntityInterface {
+    return $this->entity;
+  }
+
+  /**
+   * Gets the url.
+   *
+   * @return \Drupal\Core\Url|null
+   *   The resolved url.
+   */
+  public function getUrl(): ?Url {
+    return $this->url;
+  }
+
+  /**
+   * Sets the url.
+   *
+   * @param \Drupal\Core\Url $url
+   *   The resolved url.
+   */
+  public function setUrl(Url $url): void {
+    $this->url = $url;
+  }
+
+}

--- a/modules/oe_content_persistent/src/Form/PurlSettingsForm.php
+++ b/modules/oe_content_persistent/src/Form/PurlSettingsForm.php
@@ -92,7 +92,7 @@ class PurlSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->configFactory->getEditable('oe_content_persistent.settings')
       ->set('base_url', $form_state->getValue('base_url'))
-      ->set('supported_entity_types', $form_state->getValue('supported_entity_types'))
+      ->set('supported_entity_types', array_filter($form_state->getValue('supported_entity_types')))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/modules/oe_content_persistent/src/Form/PurlSettingsForm.php
+++ b/modules/oe_content_persistent/src/Form/PurlSettingsForm.php
@@ -31,7 +31,7 @@ class PurlSettingsForm extends ConfigFormBase {
    *   The entity type manager.
    */
   public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager) {
-    $this->setConfigFactory($config_factory);
+    parent::__construct($config_factory);
     $this->entityTypeManager = $entity_type_manager;
   }
 
@@ -76,6 +76,7 @@ class PurlSettingsForm extends ConfigFormBase {
 
     $form['supported_entity_types'] = [
       '#type' => 'checkboxes',
+      '#required' => TRUE,
       '#options' => $this->getEntityTypeOptions(),
       '#default_value' => $config->get('supported_entity_types'),
       '#title' => $this->t('Supported entity types'),

--- a/modules/oe_content_persistent/src/Form/PurlSettingsForm.php
+++ b/modules/oe_content_persistent/src/Form/PurlSettingsForm.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\oe_content_persistent\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\ContentEntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -107,7 +108,7 @@ class PurlSettingsForm extends ConfigFormBase {
     $entity_type_definitions = $this->entityTypeManager->getDefinitions();
     $entity_type_options = [];
     foreach ($entity_type_definitions as $definition) {
-      if ($definition->entityClassImplements('Drupal\Core\Entity\ContentEntityInterface')) {
+      if ($definition instanceof ContentEntityTypeInterface) {
         $entity_type_options[$definition->id()] = $definition->getLabel();
       }
     }

--- a/modules/oe_content_persistent/src/Form/PurlSettingsForm.php
+++ b/modules/oe_content_persistent/src/Form/PurlSettingsForm.php
@@ -106,7 +106,9 @@ class PurlSettingsForm extends ConfigFormBase {
     $entity_type_definitions = $this->entityTypeManager->getDefinitions();
     $entity_type_options = [];
     foreach ($entity_type_definitions as $definition) {
-      $entity_type_options[$definition->id()] = $definition->getLabel();
+      if ($definition->entityClassImplements('Drupal\Core\Entity\ContentEntityInterface')) {
+        $entity_type_options[$definition->id()] = $definition->getLabel();
+      }
     }
     return $entity_type_options;
   }

--- a/modules/oe_content_persistent/src/Form/PurlSettingsForm.php
+++ b/modules/oe_content_persistent/src/Form/PurlSettingsForm.php
@@ -6,11 +6,21 @@ namespace Drupal\oe_content_persistent\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Configuration settings form for PURL.
  */
 class PurlSettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -41,6 +51,13 @@ class PurlSettingsForm extends ConfigFormBase {
       '#description' => $this->t('The base URL to use for building persistent URLs'),
     ];
 
+    $form['supported_entity_types'] = [
+      '#type' => 'checkboxes',
+      '#options' => $this->getEntityTypeOptions(),
+      '#default_value' => $config->get('supported_entity_types'),
+      '#title' => $this->t('Supported entity types'),
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -50,9 +67,25 @@ class PurlSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->configFactory->getEditable('oe_content_persistent.settings')
       ->set('base_url', $form_state->getValue('base_url'))
+      ->set('supported_entity_types', $form_state->getValue('supported_entity_types'))
       ->save();
 
     parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Returns an array of available entity types in the site.
+   *
+   * @return array
+   *   The available entity types keyed by ID.
+   */
+  protected function getEntityTypeOptions() : array {
+    $entity_type_definitions = \Drupal::entityTypeManager()->getDefinitions();
+    $entity_type_options = [];
+    foreach ($entity_type_definitions as $definition) {
+      $entity_type_options[$definition->id()] = $definition->getLabel();
+    }
+    return $entity_type_options;
   }
 
 }

--- a/modules/oe_content_persistent/src/Form/PurlSettingsForm.php
+++ b/modules/oe_content_persistent/src/Form/PurlSettingsForm.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_content_persistent\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -14,11 +16,32 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class PurlSettingsForm extends ConfigFormBase {
 
   /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a PurlSettingsForm object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager) {
+    $this->setConfigFactory($config_factory);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('config.factory')
+      $container->get('config.factory'),
+      $container->get('entity_type.manager')
     );
   }
 
@@ -80,7 +103,7 @@ class PurlSettingsForm extends ConfigFormBase {
    *   The available entity types keyed by ID.
    */
   protected function getEntityTypeOptions() : array {
-    $entity_type_definitions = \Drupal::entityTypeManager()->getDefinitions();
+    $entity_type_definitions = $this->entityTypeManager->getDefinitions();
     $entity_type_options = [];
     foreach ($entity_type_definitions as $definition) {
       $entity_type_options[$definition->id()] = $definition->getLabel();

--- a/modules/oe_content_persistent/src/Plugin/Filter/FilterPurl.php
+++ b/modules/oe_content_persistent/src/Plugin/Filter/FilterPurl.php
@@ -128,8 +128,6 @@ class FilterPurl extends FilterBase implements ContainerFactoryPluginInterface {
         // effect of the referenced entity being deleted from the system.
         $entity = $this->contentUuidResolver->getEntityByUuid($uuid, $langcode);
         if ($entity instanceof ContentEntityInterface) {
-          // Not all entity types will need to be linked to their
-          // canonical URLs so use the url resolver to get the final URL.
           $url = $this->contentUrlResolver->resolveUrl($entity);
           $parsed_href = UrlHelper::parse($href);
           $url = $url->setOption('query', $parsed_href['query'])

--- a/modules/oe_content_persistent/src/Plugin/Filter/FilterPurl.php
+++ b/modules/oe_content_persistent/src/Plugin/Filter/FilterPurl.php
@@ -136,10 +136,9 @@ class FilterPurl extends FilterBase implements ContainerFactoryPluginInterface {
           $this->eventDispatcher->dispatch(PersistentUrlResolverEvent::NAME, $event);
           $url = is_null($event->getUrl()) ? $entity->toUrl() : $event->getUrl();
           $parsed_href = UrlHelper::parse($href);
-          $url = $url->setOptions([
-            'query' => $parsed_href['query'],
-            'fragment' => $parsed_href['fragment'],
-          ])->toString(TRUE);
+          $url = $url->setOption('query', $parsed_href['query'])
+            ->setOption('fragment', $parsed_href['fragment'])
+            ->toString(TRUE);
           $result->addCacheableDependency($entity);
         }
         else {

--- a/modules/oe_content_persistent/src/Plugin/Filter/FilterPurl.php
+++ b/modules/oe_content_persistent/src/Plugin/Filter/FilterPurl.php
@@ -8,7 +8,7 @@ use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Component\Uuid\Uuid;
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
 use Drupal\filter\FilterProcessResult;
@@ -128,7 +128,7 @@ class FilterPurl extends FilterBase implements ContainerFactoryPluginInterface {
         // we link to the 404 page of the site so that it mirrors the default
         // effect of the referenced entity being deleted from the system.
         $entity = $this->contentUuidResolver->getEntityByUuid($uuid, $langcode);
-        if ($entity instanceof EntityInterface) {
+        if ($entity instanceof ContentEntityInterface) {
           // Not all entity types will need to be linked to their
           // canonical URLs so we dispatch an event to allow to modify
           // the resulting URL.

--- a/modules/oe_content_persistent/tests/modules/oe_content_persistent_test/oe_content_persistent_test.services.yml
+++ b/modules/oe_content_persistent/tests/modules/oe_content_persistent_test/oe_content_persistent_test.services.yml
@@ -1,0 +1,5 @@
+services:
+  oe_content_persistent_test.resolver_subscriber:
+    class: \Drupal\oe_content_persistent_test\EventSubscriber\PersistentUrlResolverSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/modules/oe_content_persistent/tests/modules/oe_content_persistent_test/src/EventSubscriber/PersistentUrlResolverSubscriber.php
+++ b/modules/oe_content_persistent/tests/modules/oe_content_persistent_test/src/EventSubscriber/PersistentUrlResolverSubscriber.php
@@ -14,7 +14,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class PersistentUrlResolverSubscriber implements EventSubscriberInterface {
 
   /**
-   * We redirect articlet content types to the home page.
+   * We redirect article content types to the home page.
    *
    * @param \Drupal\oe_content_persistent\Event\PersistentUrlResolverEvent $event
    *   The Event to process.

--- a/modules/oe_content_persistent/tests/modules/oe_content_persistent_test/src/EventSubscriber/PersistentUrlResolverSubscriber.php
+++ b/modules/oe_content_persistent/tests/modules/oe_content_persistent_test/src/EventSubscriber/PersistentUrlResolverSubscriber.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_content_persistent_test\EventSubscriber;
+
+use Drupal\Core\Url;
+use Drupal\oe_content_persistent\Event\PersistentUrlResolverEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Test subscriber to alter the resolved URL of some entities.
+ */
+class PersistentUrlResolverSubscriber implements EventSubscriberInterface {
+
+  /**
+   * We redirect articlet content types to the home page.
+   *
+   * @param \Drupal\oe_content_persistent\Event\PersistentUrlResolverEvent $event
+   *   The Event to process.
+   */
+  public function testResolver(PersistentUrlResolverEvent $event): void {
+    $entity = $event->getEntity();
+    if ($entity->bundle() == 'article') {
+      $event->setUrl(Url::fromRoute('<front>'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[PersistentUrlResolverEvent::NAME][] = ['testResolver'];
+    return $events;
+  }
+
+}

--- a/modules/oe_content_persistent/tests/src/Functional/PersistentUrlControllerTest.php
+++ b/modules/oe_content_persistent/tests/src/Functional/PersistentUrlControllerTest.php
@@ -28,6 +28,7 @@ class PersistentUrlControllerTest extends BrowserTestBase {
     'dynamic_page_cache',
     'page_cache',
     'oe_content_persistent',
+    'oe_content_persistent_test',
   ];
 
   /**
@@ -42,8 +43,8 @@ class PersistentUrlControllerTest extends BrowserTestBase {
       $this->container->get('module_installer')->install(['path_alias']);
     }
 
-    $node_type = NodeType::create(['type' => 'page']);
-    $node_type->save();
+    NodeType::create(['type' => 'page'])->save();
+    NodeType::create(['type' => 'article'])->save();
   }
 
   /**
@@ -89,6 +90,22 @@ class PersistentUrlControllerTest extends BrowserTestBase {
     // Not valid uuid.
     $this->drupalGet('/content/' . $this->randomString());
     $this->assertResponse(404);
+
+    // Create a new node that will be send to the home page by the controller.
+    $node = Node::create([
+      'title' => 'Testing create()',
+      'type' => 'article',
+      'path' => ['alias' => '/bar'],
+      'status' => TRUE,
+      'uid' => 0,
+    ]);
+    $node->save();
+
+    $this->drupalGet('/content/' . $node->uuid());
+    $this->assertResponse(200);
+    // We should be redirected to the home page.
+    $this->assertUrl('/');
+    $this->assertNoText('Testing create()');
   }
 
 }

--- a/modules/oe_content_persistent/tests/src/Functional/PersistentUrlControllerTest.php
+++ b/modules/oe_content_persistent/tests/src/Functional/PersistentUrlControllerTest.php
@@ -29,6 +29,7 @@ class PersistentUrlControllerTest extends BrowserTestBase {
     'page_cache',
     'oe_content_persistent',
     'oe_content_persistent_test',
+    'path_alias',
   ];
 
   /**
@@ -36,12 +37,6 @@ class PersistentUrlControllerTest extends BrowserTestBase {
    */
   protected function setUp() {
     parent::setUp();
-
-    // In Drupal 8.8, paths have been moved to an entity type.
-    // @todo remove this when the component will depend on 8.8.
-    if (version_compare(\Drupal::VERSION, '8.8.0', '>=')) {
-      $this->container->get('module_installer')->install(['path_alias']);
-    }
 
     NodeType::create(['type' => 'page'])->save();
     NodeType::create(['type' => 'article'])->save();

--- a/modules/oe_content_persistent/tests/src/Functional/PersistentUrlControllerTest.php
+++ b/modules/oe_content_persistent/tests/src/Functional/PersistentUrlControllerTest.php
@@ -91,7 +91,7 @@ class PersistentUrlControllerTest extends BrowserTestBase {
     $this->drupalGet('/content/' . $this->randomString());
     $this->assertResponse(404);
 
-    // Create a new node that will be send to the home page by the controller.
+    // Create a new node that will be sent to the home page by the controller.
     $node = Node::create([
       'title' => 'Testing create()',
       'type' => 'article',

--- a/modules/oe_content_persistent/tests/src/Functional/PurlSettingsTest.php
+++ b/modules/oe_content_persistent/tests/src/Functional/PurlSettingsTest.php
@@ -65,8 +65,6 @@ class PurlSettingsTest extends BrowserTestBase {
     $this->assertEquals('https://custom-site.com', $config->get('base_url'));
     $expected_supported_entity_types = [
       'user' => 'user',
-      'node' => 0,
-      'path_alias' => 0,
     ];
     $this->assertEquals($expected_supported_entity_types, $config->get('supported_entity_types'));
   }

--- a/modules/oe_content_persistent/tests/src/Functional/PurlSettingsTest.php
+++ b/modules/oe_content_persistent/tests/src/Functional/PurlSettingsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_content_persistent\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests the module configuration.
+ *
+ * @group oe_content
+ */
+class PurlSettingsTest extends BrowserTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'path',
+    'node',
+    'user',
+    'system',
+    'oe_content_persistent',
+  ];
+
+  /**
+   * Tests the module settings form works as intended.
+   */
+  public function testPurlSettingsForm(): void {
+    // Log in with a user that can access the form.
+    $user = $this->createUser(['configure purl settings']);
+    $this->drupalLogin($user);
+    $this->drupalGet('/admin/config/purl/settings');
+    $this->assertResponse(200);
+    $this->assertText('PURL settings');
+
+    // Assert the default values.
+    $this->assertSession()->fieldValueEquals('Inter institutional base url', 'https://data.ec.europa.eu/ewp/');
+    $this->assertSession()->checkboxChecked('supported_entity_types[node]');
+    $this->assertSession()->checkboxNotChecked('supported_entity_types[user]');
+    $this->assertSession()->checkboxNotChecked('supported_entity_types[path_alias]');
+
+    // Try to save the form without selecting any entity type.
+    $this->getSession()->getPage()->uncheckField('supported_entity_types[node]');
+    $this->getSession()->getPage()->pressButton('Save configuration');
+
+    // Assert that the form triggered an error.
+    $this->assertSession()->pageTextContains('Supported entity types field is required.');
+
+    // Alter values and save the form.
+    $this->getSession()->getPage()->checkField('supported_entity_types[user]');
+    $this->getSession()->getPage()->fillField('Inter institutional base url', 'https://custom-site.com');
+    $this->getSession()->getPage()->pressButton('Save configuration');
+    $this->assertSession()->pageTextContains('The configuration options have been saved.');
+
+    // Assert the values where saved.
+    $this->assertSession()->fieldValueEquals('Inter institutional base url', 'https://custom-site.com');
+    $this->assertSession()->checkboxNotChecked('supported_entity_types[node]');
+    $this->assertSession()->checkboxNotChecked('supported_entity_types[path_alias]');
+    $this->assertSession()->checkboxChecked('supported_entity_types[user]');
+    $config = \Drupal::config('oe_content_persistent.settings');
+    $this->assertEquals('https://custom-site.com', $config->get('base_url'));
+    $expected_supported_entity_types = [
+      'user' => 'user',
+      'node' => 0,
+      'path_alias' => 0,
+    ];
+    $this->assertEquals($expected_supported_entity_types, $config->get('supported_entity_types'));
+  }
+
+}

--- a/modules/oe_content_persistent/tests/src/Kernel/PersistentUrlFilterTest.php
+++ b/modules/oe_content_persistent/tests/src/Kernel/PersistentUrlFilterTest.php
@@ -80,7 +80,7 @@ class PersistentUrlFilterTest extends KernelTestBase {
    */
   public function testPersistentUrlFilter(): void {
     /** @var \Drupal\oe_content_persistent\ContentUuidResolver $uuid_resolver */
-    $uuid_resolver = $this->container->get('oe_content_persistent.resolver');
+    $uuid_resolver = $this->container->get('oe_content_persistent.uuid_resolver');
 
     $filter = $this->filters['filter_purl'];
     $base_url = $this->config('oe_content_persistent.settings')->get('base_url');

--- a/modules/oe_content_persistent/tests/src/Kernel/PersistentUrlTest.php
+++ b/modules/oe_content_persistent/tests/src/Kernel/PersistentUrlTest.php
@@ -29,6 +29,7 @@ class PersistentUrlTest extends KernelTestBase {
     'language',
     'content_translation',
     'oe_content_persistent',
+    'path_alias',
   ];
 
   /**
@@ -40,18 +41,12 @@ class PersistentUrlTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
     $this->installEntitySchema('configurable_language');
+    $this->installEntitySchema('path_alias');
     $this->installSchema('node', ['node_access']);
 
     $this->installConfig(['language']);
     $this->installConfig(['user']);
-
-    // In Drupal 8.8, paths have been moved to an entity type.
-    // @todo remove this when the component will depend on 8.8.
-    if (version_compare(\Drupal::VERSION, '8.8.0', '>=')) {
-      $this->container->get('module_installer')->install(['path_alias']);
-      $this->installEntitySchema('path_alias');
-    }
-
+    $this->installConfig(['oe_content_persistent']);
     ConfigurableLanguage::create(['id' => 'fr'])->save();
 
     $node_type = NodeType::create(['type' => 'page']);
@@ -64,7 +59,7 @@ class PersistentUrlTest extends KernelTestBase {
   public function testContentUuidResolver(): void {
 
     /** @var \Drupal\oe_content_persistent\ContentUuidResolver $uuid_resolver */
-    $uuid_resolver = \Drupal::service('oe_content_persistent.resolver');
+    $uuid_resolver = $this->container->get('oe_content_persistent.resolver');
 
     $node = Node::create([
       'title' => 'Testing create()',
@@ -93,7 +88,7 @@ class PersistentUrlTest extends KernelTestBase {
     $this->assertEquals($translation->language()->getId(), $entity->language()->getId());
 
     // Check try to get not existing entity.
-    $entity = $uuid_resolver->getEntityByUuid(\Drupal::service('uuid')->generate());
+    $entity = $uuid_resolver->getEntityByUuid($this->container->get('uuid')->generate());
     $this->assertEquals(NULL, $entity);
   }
 

--- a/modules/oe_content_persistent/tests/src/Kernel/PersistentUrlTest.php
+++ b/modules/oe_content_persistent/tests/src/Kernel/PersistentUrlTest.php
@@ -59,7 +59,7 @@ class PersistentUrlTest extends KernelTestBase {
   public function testContentUuidResolver(): void {
 
     /** @var \Drupal\oe_content_persistent\ContentUuidResolver $uuid_resolver */
-    $uuid_resolver = $this->container->get('oe_content_persistent.resolver');
+    $uuid_resolver = $this->container->get('oe_content_persistent.uuid_resolver');
 
     $node = Node::create([
       'title' => 'Testing create()',


### PR DESCRIPTION
## OPENEUROPA-94

### Description

Refactor the PURL module to allow for other entity types

### Change log

- Added: Event to resolve URLs.
- Changed: Moved supported entity types to configuration.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

