### PR TITLE
EWPP-125: Make 'Venue' and 'Organiser' fields optional.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -75,6 +75,7 @@ default:
         Project contact social media links: ".field--name-oe-social-media"
         Project locations: "#edit-oe-project-locations-wrapper"
         Documents: "#edit-oe-documents"
+        Event venue: "#edit-oe-event-venue-wrapper"
       selectors:
         message_selector: '.messages'
         error_message_selector: '.messages.messages--error'

--- a/modules/oe_content_event/config/install/core.entity_form_display.node.oe_event.default.yml
+++ b/modules/oe_content_event/config/install/core.entity_form_display.node.oe_event.default.yml
@@ -403,13 +403,17 @@ content:
     settings:
       form_mode: default
       revision: true
-      label_singular: ''
-      label_plural: ''
-      override_labels: false
-      collapsible: false
+      override_labels: true
+      label_singular: venue
+      label_plural: venues
+      collapsible: true
+      allow_new: true
+      match_operator: CONTAINS
       collapsed: false
+      allow_existing: false
+      allow_duplicate: false
     third_party_settings: {  }
-    type: inline_entity_form_simple
+    type: inline_entity_form_complex
     region: content
   oe_event_website:
     weight: 12

--- a/modules/oe_content_event/config/install/core.entity_view_display.node.oe_event.default.yml
+++ b/modules/oe_content_event/config/install/core.entity_view_display.node.oe_event.default.yml
@@ -33,10 +33,11 @@ dependencies:
     - field.field.node.oe_event.oe_teaser
     - node.type.oe_event
   module:
-    - datetime
+    - datetime_range
     - entity_reference_revisions
     - link
     - options
+    - rdf_skos
     - text
     - typed_link
     - user
@@ -53,7 +54,7 @@ content:
     type: text_default
     region: content
   oe_event_contact:
-    weight: 28
+    weight: 22
     label: above
     settings:
       view_mode: default
@@ -67,18 +68,19 @@ content:
     settings:
       format_type: medium
       timezone_override: ''
+      separator: '-'
     third_party_settings: {  }
-    type: datetime_default
+    type: daterange_default
     region: content
   oe_event_description_summary:
-    weight: 15
+    weight: 12
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   oe_event_entrance_fee:
-    weight: 24
+    weight: 19
     label: above
     settings:
       link_to_entity: false
@@ -87,7 +89,7 @@ content:
     region: content
   oe_event_featured_media:
     type: entity_reference_entity_view
-    weight: 16
+    weight: 13
     label: above
     settings:
       view_mode: default
@@ -95,7 +97,7 @@ content:
     third_party_settings: {  }
     region: content
   oe_event_featured_media_legend:
-    weight: 17
+    weight: 14
     label: above
     settings:
       link_to_entity: false
@@ -103,31 +105,32 @@ content:
     type: string
     region: content
   oe_event_languages:
-    type: entity_reference_label
-    weight: 5
+    type: skos_concept_entity_reference_label
+    weight: 4
     region: content
     label: above
     settings:
       link: false
     third_party_settings: {  }
   oe_event_online_dates:
-    weight: 10
+    weight: 9
     label: above
     settings:
       format_type: medium
       timezone_override: ''
+      separator: '-'
     third_party_settings: {  }
-    type: datetime_default
+    type: daterange_default
     region: content
   oe_event_online_description:
-    weight: 9
+    weight: 8
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   oe_event_online_link:
-    weight: 12
+    weight: 10
     label: above
     settings:
       trim_length: 80
@@ -139,14 +142,32 @@ content:
     type: link
     region: content
   oe_event_online_type:
-    weight: 8
+    weight: 7
     label: above
     settings: {  }
     third_party_settings: {  }
     type: list_default
     region: content
+  oe_event_organiser_internal:
+    type: skos_concept_entity_reference_label
+    weight: 25
+    region: content
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+  oe_event_organiser_is_internal:
+    type: boolean
+    weight: 24
+    region: content
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
   oe_event_organiser_name:
-    weight: 13
+    weight: 11
     label: above
     settings:
       link_to_entity: false
@@ -154,7 +175,7 @@ content:
     type: string
     region: content
   oe_event_registration_capacity:
-    weight: 25
+    weight: 20
     label: above
     settings:
       link_to_entity: false
@@ -162,16 +183,17 @@ content:
     type: string
     region: content
   oe_event_registration_dates:
-    weight: 22
+    weight: 18
     label: above
     settings:
       format_type: medium
       timezone_override: ''
+      separator: '-'
     third_party_settings: {  }
-    type: datetime_default
+    type: daterange_default
     region: content
   oe_event_registration_url:
-    weight: 20
+    weight: 17
     label: above
     settings:
       trim_length: 80
@@ -183,36 +205,37 @@ content:
     type: link
     region: content
   oe_event_report_summary:
-    weight: 18
+    weight: 15
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   oe_event_report_text:
-    weight: 19
+    weight: 16
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   oe_event_status:
-    weight: 4
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    type: list_default
-    region: content
-  oe_event_type:
     weight: 3
     label: above
     settings: {  }
     third_party_settings: {  }
     type: list_default
     region: content
+  oe_event_type:
+    weight: 2
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: skos_concept_entity_reference_label
+    region: content
   oe_event_venue:
     type: entity_reference_revisions_entity_view
-    weight: 26
+    weight: 21
     region: content
     label: above
     settings:
@@ -220,7 +243,7 @@ content:
       link: ''
     third_party_settings: {  }
   oe_event_website:
-    weight: 6
+    weight: 5
     label: above
     settings:
       trim_length: 80
@@ -233,7 +256,7 @@ content:
     region: content
   oe_social_media_links:
     type: typed_link
-    weight: 7
+    weight: 6
     region: content
     label: above
     settings:
@@ -244,7 +267,7 @@ content:
       target: ''
     third_party_settings: {  }
   oe_summary:
-    weight: 29
+    weight: 23
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -258,7 +281,5 @@ hidden:
   oe_content_legacy_link: true
   oe_content_navigation_title: true
   oe_content_short_title: true
-  oe_event_organiser_internal: true
-  oe_event_organiser_is_internal: true
   oe_subject: true
   oe_teaser: true

--- a/modules/oe_content_event/config/install/field.field.node.oe_event.body.yml
+++ b/modules/oe_content_event/config/install/field.field.node.oe_event.body.yml
@@ -18,4 +18,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   display_summary: false
+  required_summary: false
 field_type: text_with_summary

--- a/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_contact.yml
+++ b/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_contact.yml
@@ -31,5 +31,5 @@ settings:
     sort:
       field: _none
     auto_create: false
-    auto_create_bundle: general
+    auto_create_bundle: oe_general
 field_type: entity_reference_revisions

--- a/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_contact.yml
+++ b/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_contact.yml
@@ -7,8 +7,8 @@ dependencies:
     - oe_content_entity_contact.oe_contact_type.oe_general
     - oe_content_entity_contact.oe_contact_type.oe_press
   module:
+    - composite_reference
     - entity_reference_revisions
-    - oe_content
 third_party_settings:
   composite_reference:
     composite: true

--- a/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_venue.yml
+++ b/modules/oe_content_event/config/install/field.field.node.oe_event.oe_event_venue.yml
@@ -6,8 +6,8 @@ dependencies:
     - node.type.oe_event
     - oe_content_entity_venue.oe_venue_type.oe_default
   module:
+    - composite_reference
     - entity_reference_revisions
-    - oe_content
 third_party_settings:
   composite_reference:
     composite: true

--- a/modules/oe_content_event/oe_content_event.info.yml
+++ b/modules/oe_content_event/oe_content_event.info.yml
@@ -8,7 +8,6 @@ dependencies:
   - drupal:composite_reference
   - oe_content:oe_content
   - oe_content:oe_content_entity_contact
-  - oe_content:oe_content_entity_contact
   - oe_content:oe_content_entity_organisation
   - oe_content:oe_content_entity_venue
   - oe_content:oe_content_social_media_links_field

--- a/modules/oe_content_event/oe_content_event.module
+++ b/modules/oe_content_event/oe_content_event.module
@@ -38,12 +38,12 @@ function oe_content_event_node_presave(EntityInterface $entity) {
  * Implements hook_form_FORM_ID_alter().
  */
 function oe_content_event_form_node_oe_event_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  ContentFormUtilities::toggleFieldsWithCheckbox($form, 'oe_event_organiser_is_internal', 'oe_event_organiser_internal', 'oe_event_organiser_name');
+  ContentFormUtilities::toggleFieldsWithCheckbox($form, 'oe_event_organiser_is_internal', 'oe_event_organiser_internal', 'oe_event_organiser_name', FALSE);
 }
 
 /**
  * Implements hook_form_FORM_ID_alter().
  */
 function oe_content_event_form_node_oe_event_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  ContentFormUtilities::toggleFieldsWithCheckbox($form, 'oe_event_organiser_is_internal', 'oe_event_organiser_internal', 'oe_event_organiser_name');
+  ContentFormUtilities::toggleFieldsWithCheckbox($form, 'oe_event_organiser_is_internal', 'oe_event_organiser_internal', 'oe_event_organiser_name', FALSE);
 }

--- a/modules/oe_content_event/oe_content_event.module
+++ b/modules/oe_content_event/oe_content_event.module
@@ -38,12 +38,12 @@ function oe_content_event_node_presave(EntityInterface $entity) {
  * Implements hook_form_FORM_ID_alter().
  */
 function oe_content_event_form_node_oe_event_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  ContentFormUtilities::toggleFieldsWithCheckbox($form, 'oe_event_organiser_is_internal', 'oe_event_organiser_internal', 'oe_event_organiser_name', FALSE);
+  ContentFormUtilities::toggleFieldsWithCheckbox($form, 'oe_event_organiser_is_internal', 'oe_event_organiser_internal', 'oe_event_organiser_name');
 }
 
 /**
  * Implements hook_form_FORM_ID_alter().
  */
 function oe_content_event_form_node_oe_event_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  ContentFormUtilities::toggleFieldsWithCheckbox($form, 'oe_event_organiser_is_internal', 'oe_event_organiser_internal', 'oe_event_organiser_name', FALSE);
+  ContentFormUtilities::toggleFieldsWithCheckbox($form, 'oe_event_organiser_is_internal', 'oe_event_organiser_internal', 'oe_event_organiser_name');
 }

--- a/modules/oe_content_event/oe_content_event.post_update.php
+++ b/modules/oe_content_event/oe_content_event.post_update.php
@@ -8,6 +8,7 @@
 declare(strict_types = 1);
 
 use Drupal\field\Entity\FieldConfig;
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
 
 /**
  * Make the Event venue and contact fields composite.
@@ -29,8 +30,51 @@ function oe_content_event_post_update_00001(array &$sandbox) {
 /**
  * Make the Event venue not required.
  */
-function oe_content_event_post_update_00002(array &$sandbox) {
+function oe_content_event_post_update_00002(array &$sandbox): void {
   $field_config = FieldConfig::load('node.oe_event.oe_event_venue');
   $field_config->set('required', FALSE);
+  $field_config->save();
+}
+
+/**
+ * Change event venue reference widget to inline_entity_form_complex.
+ */
+function oe_content_event_post_update_00003(array &$sandbox): void {
+  $form_display = EntityFormDisplay::load('node.oe_event.default');
+  $content = $form_display->get('content') ?: [];
+  if (!isset($content['oe_event_venue'])) {
+    return;
+  }
+
+  $content['oe_event_venue']['type'] = 'inline_entity_form_complex';
+  $content['oe_event_venue']['settings'] = [
+    'form_mode' => 'default',
+    'revision' => TRUE,
+    'override_labels' => TRUE,
+    'label_singular' => 'venue',
+    'label_plural' => 'venues',
+    'collapsible' => TRUE,
+    'allow_new' => TRUE,
+    'match_operator' => 'CONTAINS',
+    'collapsed' => FALSE,
+    'allow_existing' => FALSE,
+    'allow_duplicate' => FALSE,
+  ];
+  $content['oe_event_venue']['third_party_settings'] = [];
+  $form_display->set('content', $content);
+  $form_display->save();
+}
+
+/**
+ * Fix auto_create_bundle on event contact reference field.
+ */
+function oe_content_event_post_update_00004(array &$sandbox): void {
+  $field_config = FieldConfig::load('node.oe_event.oe_event_contact');
+  $settings = $field_config->get('settings');
+  if ($settings['handler'] !== 'default:oe_contact') {
+    return;
+  }
+  $settings['handler_settings']['auto_create_bundle'] = 'oe_general';
+  $field_config->set('settings', $settings);
   $field_config->save();
 }

--- a/modules/oe_content_event/oe_content_event.post_update.php
+++ b/modules/oe_content_event/oe_content_event.post_update.php
@@ -25,3 +25,12 @@ function oe_content_event_post_update_00001(array &$sandbox) {
     $field_config->save();
   }
 }
+
+/**
+ * Make the Event venue not required.
+ */
+function oe_content_event_post_update_00002(array &$sandbox) {
+  $field_config = FieldConfig::load('node.oe_event.oe_event_venue');
+  $field_config->set('required', FALSE);
+  $field_config->save();
+}

--- a/modules/oe_content_event/src/Plugin/Validation/Constraint/EventFieldsRequiredValidator.php
+++ b/modules/oe_content_event/src/Plugin/Validation/Constraint/EventFieldsRequiredValidator.php
@@ -7,7 +7,6 @@ namespace Drupal\oe_content_event\Plugin\Validation\Constraint;
 use Drupal\node\NodeInterface;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 /**
  * Checks if the event fields are provided if required.
@@ -23,7 +22,6 @@ class EventFieldsRequiredValidator extends ConstraintValidator {
       return;
     }
 
-    $this->validateOrganiserGroupFields($constraint, $node);
     $this->validateRegistrationGroupFields($constraint, $node);
 
     $online_required_fields = [
@@ -73,42 +71,6 @@ class EventFieldsRequiredValidator extends ConstraintValidator {
             ->addViolation();
         }
       }
-    }
-  }
-
-  /**
-   * Validate organiser information consistency.
-   *
-   * An organiser can either be a custom string or a reference to a corporate
-   * vocabulary, depending from the value of `oe_event_organiser_is_internal`.
-   *
-   * This tests that, if one is set, the other is always not, depending
-   * whether the organiser is marked as internal or not.
-   *
-   * @param \Symfony\Component\Validator\Constraint $constraint
-   *   The constraint object.
-   * @param \Drupal\node\NodeInterface $node
-   *   The node object.
-   */
-  protected function validateOrganiserGroupFields(Constraint $constraint, NodeInterface $node) {
-    $violation = NULL;
-    if ($node->get('oe_event_organiser_internal')->isEmpty() && $node->get('oe_event_organiser_name')->isEmpty()) {
-      $violation = $this->context->buildViolation('You have to fill in at least one of the following fields: @internal or @organiser_name', [
-        '@internal' => $node->getFieldDefinition('oe_event_organiser_internal')->getLabel(),
-        '@organiser_name' => $node->getFieldDefinition('oe_event_organiser_name')->getLabel(),
-      ]);
-    }
-
-    if ($violation instanceof ConstraintViolationBuilderInterface) {
-      // Highlight empty 'Organiser name' field.
-      (clone $violation)
-        ->atPath('oe_event_organiser_name')
-        ->addViolation();
-
-      // Highlight empty 'Internal organiser' field.
-      $violation
-        ->atPath('oe_event_organiser_internal')
-        ->addViolation();
     }
   }
 

--- a/modules/oe_content_event/src/Plugin/Validation/Constraint/EventFieldsRequiredValidator.php
+++ b/modules/oe_content_event/src/Plugin/Validation/Constraint/EventFieldsRequiredValidator.php
@@ -7,7 +7,6 @@ namespace Drupal\oe_content_event\Plugin\Validation\Constraint;
 use Drupal\node\NodeInterface;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 /**
  * Checks if the event fields are provided if required.
@@ -23,7 +22,6 @@ class EventFieldsRequiredValidator extends ConstraintValidator {
       return;
     }
 
-    $this->validateOrganiserGroupFields($constraint, $node);
     $this->validateRegistrationGroupFields($constraint, $node);
 
     $online_required_fields = [
@@ -73,58 +71,6 @@ class EventFieldsRequiredValidator extends ConstraintValidator {
             ->addViolation();
         }
       }
-    }
-  }
-
-  /**
-   * Validate organiser information consistency.
-   *
-   * An organiser can either be a custom string or a reference to a corporate
-   * vocabulary, depending from the value of `oe_event_organiser_is_internal`.
-   *
-   * This tests that, if one is set, the other is always not, depending
-   * whether the organiser is marked as internal or not.
-   *
-   * @param \Symfony\Component\Validator\Constraint $constraint
-   *   The constraint object.
-   * @param \Drupal\node\NodeInterface $node
-   *   The node object.
-   */
-  protected function validateOrganiserGroupFields(Constraint $constraint, NodeInterface $node) {
-    if ($node->get('oe_event_organiser_internal')->isEmpty() && $node->get('oe_event_organiser_name')->isEmpty()) {
-      return;
-    }
-
-    $violation = NULL;
-    $oe_event_organiser_is_internal_value = (bool) $node->get('oe_event_organiser_is_internal')->value;
-
-    if (!$oe_event_organiser_is_internal_value && !$node->get('oe_event_organiser_internal')->isEmpty()) {
-      // If checkbox "Organiser is internal" isn't checked,
-      // field "Internal organiser" has to be empty.
-      $violation = $this->context->buildViolation('When @is_internal field is not checked, @internal field have to be empty.', [
-        '@is_internal' => $node->getFieldDefinition('oe_event_organiser_is_internal')->getLabel(),
-        '@internal' => $node->getFieldDefinition('oe_event_organiser_internal')->getLabel(),
-      ]);
-    }
-
-    if ($oe_event_organiser_is_internal_value && !$node->get('oe_event_organiser_name')->isEmpty()) {
-      // If checkbox "Organiser is internal" is checked,
-      // field "Organiser name" has to be empty.
-      $violation = $this->context->buildViolation('When @is_internal field is checked, @organiser_name field has to be empty.', [
-        '@is_internal' => $node->getFieldDefinition('oe_event_organiser_is_internal')->getLabel(),
-        '@organiser_name' => $node->getFieldDefinition('oe_event_organiser_name')->getLabel(),
-      ]);
-    }
-
-    if ($violation instanceof ConstraintViolationBuilderInterface) {
-      // Highlight both fields because checkbox "Organiser is internal" can not
-      // be highlighted and field with error is hidden.
-      (clone $violation)
-        ->atPath('oe_event_organiser_name')
-        ->addViolation();
-      $violation
-        ->atPath('oe_event_organiser_internal')
-        ->addViolation();
     }
   }
 

--- a/modules/oe_content_event/src/Plugin/Validation/Constraint/EventFieldsRequiredValidator.php
+++ b/modules/oe_content_event/src/Plugin/Validation/Constraint/EventFieldsRequiredValidator.php
@@ -7,6 +7,7 @@ namespace Drupal\oe_content_event\Plugin\Validation\Constraint;
 use Drupal\node\NodeInterface;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 /**
  * Checks if the event fields are provided if required.
@@ -22,6 +23,7 @@ class EventFieldsRequiredValidator extends ConstraintValidator {
       return;
     }
 
+    $this->validateOrganiserGroupFields($constraint, $node);
     $this->validateRegistrationGroupFields($constraint, $node);
 
     $online_required_fields = [
@@ -71,6 +73,58 @@ class EventFieldsRequiredValidator extends ConstraintValidator {
             ->addViolation();
         }
       }
+    }
+  }
+
+  /**
+   * Validate organiser information consistency.
+   *
+   * An organiser can either be a custom string or a reference to a corporate
+   * vocabulary, depending from the value of `oe_event_organiser_is_internal`.
+   *
+   * This tests that, if one is set, the other is always not, depending
+   * whether the organiser is marked as internal or not.
+   *
+   * @param \Symfony\Component\Validator\Constraint $constraint
+   *   The constraint object.
+   * @param \Drupal\node\NodeInterface $node
+   *   The node object.
+   */
+  protected function validateOrganiserGroupFields(Constraint $constraint, NodeInterface $node) {
+    if ($node->get('oe_event_organiser_internal')->isEmpty() && $node->get('oe_event_organiser_name')->isEmpty()) {
+      return;
+    }
+
+    $violation = NULL;
+    $oe_event_organiser_is_internal_value = (bool) $node->get('oe_event_organiser_is_internal')->value;
+
+    if (!$oe_event_organiser_is_internal_value && !$node->get('oe_event_organiser_internal')->isEmpty()) {
+      // If checkbox "Organiser is internal" isn't checked,
+      // field "Internal organiser" has to be empty.
+      $violation = $this->context->buildViolation('When @is_internal field is not checked, @internal field have to be empty.', [
+        '@is_internal' => $node->getFieldDefinition('oe_event_organiser_is_internal')->getLabel(),
+        '@internal' => $node->getFieldDefinition('oe_event_organiser_internal')->getLabel(),
+      ]);
+    }
+
+    if ($oe_event_organiser_is_internal_value && !$node->get('oe_event_organiser_name')->isEmpty()) {
+      // If checkbox "Organiser is internal" is checked,
+      // field "Organiser name" has to be empty.
+      $violation = $this->context->buildViolation('When @is_internal field is checked, @organiser_name field has to be empty.', [
+        '@is_internal' => $node->getFieldDefinition('oe_event_organiser_is_internal')->getLabel(),
+        '@organiser_name' => $node->getFieldDefinition('oe_event_organiser_name')->getLabel(),
+      ]);
+    }
+
+    if ($violation instanceof ConstraintViolationBuilderInterface) {
+      // Highlight both fields because checkbox "Organiser is internal" can not
+      // be highlighted and field with error is hidden.
+      (clone $violation)
+        ->atPath('oe_event_organiser_name')
+        ->addViolation();
+      $violation
+        ->atPath('oe_event_organiser_internal')
+        ->addViolation();
     }
   }
 

--- a/src/Utility/ContentFormUtilities.php
+++ b/src/Utility/ContentFormUtilities.php
@@ -21,19 +21,19 @@ class ContentFormUtilities {
    * @param string $field2
    *   The second dependent field name.
    * @param bool $is_required
-   *   Does the field 1 and field 2 have to be required ?
+   *   Flag to set field 1 and field 2 required.
    */
-  public static function toggleFieldsWithCheckbox(array &$form, string $checkbox_field, string $field1, string $field2, $is_required = TRUE): void {
+  public static function toggleFieldsWithCheckbox(array &$form, string $checkbox_field, string $field1, string $field2, $is_required = FALSE): void {
     $condition_checked = [':input[name="' . $checkbox_field . '[value]"]' => ['checked' => TRUE]];
     $condition_unchecked = [':input[name="' . $checkbox_field . '[value]"]' => ['checked' => FALSE]];
 
+    // Set rules for visibility of elements.
     $form[$field1]['#states']['visible'] = $condition_checked;
-    if ($is_required) {
-      $form[$field1]['#states']['required'] = $condition_checked;
-    }
-
     $form[$field2]['#states']['visible'] = $condition_unchecked;
+
     if ($is_required) {
+      // Set rules if fields have to be required.
+      $form[$field1]['#states']['required'] = $condition_checked;
       $form[$field2]['#states']['required'] = $condition_unchecked;
     }
   }

--- a/src/Utility/ContentFormUtilities.php
+++ b/src/Utility/ContentFormUtilities.php
@@ -21,7 +21,7 @@ class ContentFormUtilities {
    * @param string $field2
    *   The second dependent field name.
    * @param bool $is_required
-   *   Flag to set field 1 and field 2 required.
+   *   Set to TRUE if both fields are supposed to be required.
    */
   public static function toggleFieldsWithCheckbox(array &$form, string $checkbox_field, string $field1, string $field2, $is_required = FALSE): void {
     $condition_checked = [':input[name="' . $checkbox_field . '[value]"]' => ['checked' => TRUE]];

--- a/src/Utility/ContentFormUtilities.php
+++ b/src/Utility/ContentFormUtilities.php
@@ -20,32 +20,22 @@ class ContentFormUtilities {
    *   The first dependent field name.
    * @param string $field2
    *   The second dependent field name.
+   * @param bool $is_required
+   *   Does the field 1 and field 2 have to be required ?
    */
-  public static function toggleFieldsWithCheckbox(array &$form, string $checkbox_field, string $field1, string $field2): void {
-    $form[$field1]['#states'] = [
-      'visible' => [
-        [
-          ':input[name="' . $checkbox_field . '[value]"]' => ['checked' => TRUE],
-        ],
-      ],
-      'required' => [
-        [
-          ':input[name="' . $checkbox_field . '[value]"]' => ['checked' => TRUE],
-        ],
-      ],
-    ];
-    $form[$field2]['#states'] = [
-      'visible' => [
-        [
-          ':input[name="' . $checkbox_field . '[value]"]' => ['checked' => FALSE],
-        ],
-      ],
-      'required' => [
-        [
-          ':input[name="' . $checkbox_field . '[value]"]' => ['checked' => FALSE],
-        ],
-      ],
-    ];
+  public static function toggleFieldsWithCheckbox(array &$form, string $checkbox_field, string $field1, string $field2, $is_required = TRUE): void {
+    $condition_checked = [':input[name="' . $checkbox_field . '[value]"]' => ['checked' => TRUE]];
+    $condition_unchecked = [':input[name="' . $checkbox_field . '[value]"]' => ['checked' => FALSE]];
+
+    $form[$field1]['#states']['visible'] = $condition_checked;
+    if ($is_required) {
+      $form[$field1]['#states']['required'] = $condition_checked;
+    }
+
+    $form[$field2]['#states']['visible'] = $condition_unchecked;
+    if ($is_required) {
+      $form[$field2]['#states']['required'] = $condition_unchecked;
+    }
   }
 
 }

--- a/tests/features/event.feature
+++ b/tests/features/event.feature
@@ -315,26 +315,24 @@ Feature: Event content creation
     And I fill in "Content owner" with "Committee on Agriculture and Rural Development"
     And I fill in "Responsible department" with "Audit Board of the European Communities"
     And I fill in "Teaser" with "Event teaser"
-    # Make sure that errors related to the Organiser fields work properly.
+
+    # Make sure that one value is saved, even if both are filled in.
     When I check "Organiser is internal"
     And I fill in "Internal organiser" with "Audit Board of the European Communities"
     And I uncheck "Organiser is internal"
     And I fill in "Organiser name" with "Organiser external"
     And I press "Save"
-    Then I should see the following error messages:
-      | error messages                                                                              |
-      | When Organiser is internal field is not checked, Internal organiser field have to be empty. |
-    When I check "Organiser is internal"
-    And I press "Save"
-    Then I should see the following error messages:
-      | error messages                                                                     |
-      | When Organiser is internal field is checked, Organiser name field has to be empty. |
-    When I fill in "Internal organiser" with ""
+    Then I should see "Organiser name Organiser external"
+    But I should not see "Internal organiser Audit Board of the European Communities"
+
+    When I click "Edit"
     And I uncheck "Organiser is internal"
+    And I fill in "Organiser name" with "Organiser external"
+    And I check "Organiser is internal"
+    And I fill in "Internal organiser" with "Audit Board of the European Communities"
     And I press "Save"
-    Then I should see the following success messages:
-      | success messages                      |
-      | Event My Event item has been created. |
+    Then I should not see "Organiser name Organiser external"
+    But I should see "Internal organiser Audit Board of the European Communities"
 
     # Make sure that validation of the Online fields group works as expected.
     When I click "Edit"
@@ -343,7 +341,7 @@ Feature: Event content creation
     And I press "Save"
     Then I should see the following error messages:
       | error messages                       |
-      | Online time field is required. |
+      | Online time field is required.       |
       | Online link field is required.       |
     # Make sure that errors related to the Online fields are fixed.
     And I set "22-02-2019 02:30" as the "Start date" of "Online time"

--- a/tests/features/event.feature
+++ b/tests/features/event.feature
@@ -300,6 +300,11 @@ Feature: Event content creation
   @javascript @av_portal
   Scenario: As an editor when I create an Event node, the required fields are correctly marked when not filled in.
     Given I am logged in as a user with the "create oe_event content, access content, edit own oe_event content, view published skos concept entities" permission
+    # Create a "Media AV portal photo".
+    And the following AV Portal photos:
+      | url                                                         |
+      | https://audiovisual.ec.europa.eu/en/photo/P-038924~2F00-15  |
+
     # Create a "Event" content.
     When I visit "the Event creation page"
     And I fill in "Page title" with "My Event item"

--- a/tests/features/event.feature
+++ b/tests/features/event.feature
@@ -57,6 +57,8 @@ Feature: Event content creation
 
      # The venue group is open by default.
     And I should see the text "Venue"
+    When I press "Add new venue"
+    And I wait for AJAX to finish
     And I should see the text "Name"
     And I should see the text "Capacity"
     And I should see the text "Room"
@@ -169,16 +171,18 @@ Feature: Event content creation
     And I fill in "Subject" with "EU financing"
     And I set "21-02-2019 02:15" as the "Start date" of "Event date"
     And I set "21-02-2019 14:15" as the "End date" of "Event date"
-    # Venue reference by inline entity form.
-    And I fill in "Name" with "Name of the venue"
-    And I fill in "Capacity" with "Capacity of the venue"
-    And I fill in "Room" with "Room of the venue"
-    And I select "Belgium" from "Country"
+    # Venue reference by Inline entity form - Complex.
+    When I press "Add new venue"
     And I wait for AJAX to finish
-    And I fill in "Street address" with "Rue belliard 28"
-    And I fill in "Postal code" with "1000"
-    And I fill in "City" with "Brussels"
-
+    Then I fill in "Name" with "Name of the venue" in the "Event venue" region
+    And I fill in "Capacity" with "Capacity of the venue" in the "Event venue" region
+    And I fill in "Room" with "Room of the venue" in the "Event venue" region
+    And I select "Belgium" from "Country" in the "Event venue" region
+    And I wait for AJAX to finish
+    And I fill in "Street address" with "Rue belliard 28" in the "Event venue" region
+    And I fill in "Postal code" with "1000" in the "Event venue" region
+    And I fill in "City" with "Brussels" in the "Event venue" region
+    And I press "Create venue"
     # Online field group.
     When I press "Online"
     Then I select "Facebook" from "Online type"
@@ -311,10 +315,6 @@ Feature: Event content creation
     And I fill in "Content owner" with "Committee on Agriculture and Rural Development"
     And I fill in "Responsible department" with "Audit Board of the European Communities"
     And I fill in "Teaser" with "Event teaser"
-    And I press "Save"
-    Then I should see the following error messages:
-      | error messages                                                                                 |
-      | You have to fill in at least one of the following fields: Internal organiser or Organiser name |
     # Make sure that errors related to the Organiser fields are fixed.
     When I check "Organiser is internal"
     And I fill in "Internal organiser" with "Audit Board of the European Communities"

--- a/tests/features/event.feature
+++ b/tests/features/event.feature
@@ -300,11 +300,6 @@ Feature: Event content creation
   @javascript @av_portal
   Scenario: As an editor when I create an Event node, the required fields are correctly marked when not filled in.
     Given I am logged in as a user with the "create oe_event content, access content, edit own oe_event content, view published skos concept entities" permission
-    # Create a "Media AV portal photo".
-    And the following AV Portal photos:
-      | url                                                         |
-      | https://audiovisual.ec.europa.eu/en/photo/P-038924~2F00-15  |
-
     # Create a "Event" content.
     When I visit "the Event creation page"
     And I fill in "Page title" with "My Event item"
@@ -315,25 +310,26 @@ Feature: Event content creation
     And I fill in "Content owner" with "Committee on Agriculture and Rural Development"
     And I fill in "Responsible department" with "Audit Board of the European Communities"
     And I fill in "Teaser" with "Event teaser"
-    # Make sure that errors related to the Organiser fields are fixed.
+    # Make sure that errors related to the Organiser fields work properly.
     When I check "Organiser is internal"
     And I fill in "Internal organiser" with "Audit Board of the European Communities"
+    And I uncheck "Organiser is internal"
+    And I fill in "Organiser name" with "Organiser external"
+    And I press "Save"
+    Then I should see the following error messages:
+      | error messages                                                                              |
+      | When Organiser is internal field is not checked, Internal organiser field have to be empty. |
+    When I check "Organiser is internal"
+    And I press "Save"
+    Then I should see the following error messages:
+      | error messages                                                                     |
+      | When Organiser is internal field is checked, Organiser name field has to be empty. |
+    When I fill in "Internal organiser" with ""
+    And I uncheck "Organiser is internal"
     And I press "Save"
     Then I should see the following success messages:
       | success messages                      |
       | Event My Event item has been created. |
-
-    # Make sure that only one organiser field value is stored depending on the "Organiser is internal" checkbox.
-    When I click "Edit"
-    And I uncheck "Organiser is internal"
-    And I fill in "Organiser name" with "VALUE NOT TO STORE"
-    And I check "Organiser is internal"
-    And I press "Save"
-    Then I should see the following success messages:
-      | success messages                      |
-      | Event My Event item has been updated. |
-    And I should not see the text "Organiser name"
-    And I should not see the text "VALUE NOT TO STORE"
 
     # Make sure that validation of the Online fields group works as expected.
     When I click "Edit"


### PR DESCRIPTION
## EWPP-125

### Description

Event ; make 'Venue' and 'Organiser' fields optional.

### Change log

- Changed:
  - Venue field is not mandatory
    - widget "Inline entity form - Complex" is now used
  - Organiser field is not mandatory
    - removed useless Validation
  - Behat tests about required fieds
