### PR TITLE
EWPP-196: Fix inline entity edit form duplicate form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "drupal/entity_embed": "~1.0",
         "drupal/entity_reference_revisions": "~1.3",
         "drupal/field_group": "~3.0",
-        "drupal/inline_entity_form": "~1.0-rc3",
+        "drupal/inline_entity_form": "~1.0-rc7",
         "drupal/typed_link": "~1.1",
         "drupaltest/behat-traits": "dev-8.x-1.x",
         "drush/drush": "~9.0",

--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,9 @@
         "patches": {
             "drupal/field_group": {
                 "https://www.drupal.org/project/field_group/issues/2787179#comment-13467953": "https://www.drupal.org/files/issues/2020-02-17/2787179-highlight-html5-validation-45.patch"
+            },
+            "drupal/inline_entity_form": {
+                "https://www.drupal.org/project/inline_entity_form/issues/3162384": "https://www.drupal.org/files/issues/2020-08-13/fixed_duplicate_rows-3162384-16.patch"
             }
         }
     },

--- a/modules/oe_content_event/README.md
+++ b/modules/oe_content_event/README.md
@@ -12,7 +12,7 @@ Before enabling this module, make sure that the following modules are present in
     "drupal/composite_reference": "~1.0-alpha1",
     "drupal/entity_reference_revisions": "~1.3",
     "drupal/field_group": "~3.0",
-    "drupal/inline_entity_form": "~1.0-rc3",
+    "drupal/inline_entity_form": "~1.0-rc7",
     "drupal/typed_link": "~1.1",
     "openeuropa/oe_corporate_countries": "~1.0.0-beta1"
 }
@@ -24,6 +24,16 @@ The `field_group` module requires the following patches to be applied:
 "patches": {
     "drupal/field_group": {
         "https://www.drupal.org/project/field_group/issues/2787179#comment-13467953": "https://www.drupal.org/files/issues/2020-02-17/2787179-highlight-html5-validation-45.patch"
+    }
+}
+```
+
+The `inline_entity_form` module requires the following patches to be applied:
+
+```json
+"patches": {
+    "drupal/inline_entity_form": {
+        "https://www.drupal.org/project/inline_entity_form/issues/3162384": "https://www.drupal.org/files/issues/2020-08-13/fixed_duplicate_rows-3162384-16.patch"
     }
 }
 ```


### PR DESCRIPTION
## EWPP-196

### Description

Fix inline entity edit form duplicate form.

### Change log

- Added: patch fixed_duplicate_rows-3162384-16.patch


