### PR TITLE
EWPP-313: Media entity reference is replaced with content owner after removing media.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "drupal/config_devel": "~1.2",
         "drupal/datetime_testing": "1.x-dev",
         "drupal/drupal-extension": "~4.0",
-        "drupal/entity_browser": "^2.3",
+        "drupal/entity_browser": "^2.5",
         "drupal/entity_embed": "~1.0",
         "drupal/entity_reference_revisions": "~1.3",
         "drupal/field_group": "~3.0",
@@ -86,6 +86,9 @@
             },
             "drupal/address": {
                 "https://www.drupal.org/project/address/issues/2723917#comment-13844025": "https://www.drupal.org/files/issues/2020-10-02/address-multiple_value-2723917-13.patch"
+            },
+            "drupal/entity_browser": {
+                "https://www.drupal.org/project/entity_browser/issues/2851580": "https://www.drupal.org/files/issues/2020-10-05/entity_browser-remove_button_2851580-92.patch"
             }
         }
     },


### PR DESCRIPTION
## EWPP-313: Stakeholder Logo media entity reference is replaced with content owner after removing media.

### Description

Patch https://www.drupal.org/project/entity_browser/issues/2851580#comment-13667638 for entity browser resolves the issue.

This ticket has to be tested in EWCMS.

