### PR TITLE
HOTFIX: Call for tenders README according dependencies.

### DIFF
--- a/modules/oe_content_call_tenders/README.md
+++ b/modules/oe_content_call_tenders/README.md
@@ -9,6 +9,7 @@ Before enabling this module, make sure the following modules are present in your
 
 ```json
 "require": {
+    "drupal/composite_reference": "~1.0-alpha2",
     "drupal/entity_reference_revisions": "~1.3",
     "drupal/field_group": "~3.0",
 }


### PR DESCRIPTION
### Description

Update the instructions for Call for tenders usage.

### Change log

- Added:
  - `"drupal/composite_reference": "~1.0-alpha2",` to README of oe_content_call_tenders

