### PR TITLE
EWPP-371: Remove non necessary context from translations.

### DIFF
--- a/translations/oe_content-cs.po
+++ b/translations/oe_content-cs.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "Prosinec"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Led"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Úno"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Bře"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Dub"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "Kvě"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Čvn"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Čvc"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Srp"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "Zář"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "Říj"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Lis"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Pro"
 

--- a/translations/oe_content-da.po
+++ b/translations/oe_content-da.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "december"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "jan"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "feb"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "mar"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "apr"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "maj"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "jun"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "jul"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "aug"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "sep"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "okt"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "nov"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "dec"
 

--- a/translations/oe_content-de.po
+++ b/translations/oe_content-de.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "Dezember"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Jan"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Feb"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Mär"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Apr"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "Mai"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Jun"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Jul"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Aug"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "Sep"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "Okt"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Nov"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Dez"
 

--- a/translations/oe_content-el.po
+++ b/translations/oe_content-el.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "Δεκέμβριος"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Ιαν"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Φεβ"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Μαρ"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Απρ"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "Μαι"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Ιουν"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Ιουλ"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Αυγ"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "Σεπ"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "Οκτ"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Νοε"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Δεκ"
 

--- a/translations/oe_content-es.po
+++ b/translations/oe_content-es.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "Diciembre"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Ene"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Feb"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Mar"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Abr"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "May"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Jun"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Jul"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Ago"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "Sep"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "Oct"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Nov"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Dic"
 

--- a/translations/oe_content-et.po
+++ b/translations/oe_content-et.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "detsember"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "jaan"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "veebr"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "märts"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "apr"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "mai"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "juuni"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "juuli"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "aug"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "sept"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "okt"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "nov"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "dets"
 

--- a/translations/oe_content-fi.po
+++ b/translations/oe_content-fi.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "joulukuu"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Tam"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Hel"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Maa"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Huh"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "Tou"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Kes"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Hei"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Elo"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "Syy"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "Lok"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Mar"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Jou"
 

--- a/translations/oe_content-fr.po
+++ b/translations/oe_content-fr.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "décembre"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Jan"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Fév"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Mar"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Avr"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "Mai"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Jun"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Jul"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Aoû"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "Sep"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "Oct"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Nov"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Déc"
 

--- a/translations/oe_content-ga.po
+++ b/translations/oe_content-ga.po
@@ -49,47 +49,36 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "Nollaig"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Ean"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Fea"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Már"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Aib"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Mei"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Iúil"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Lún"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "MF"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "DF"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Samh"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Noll"
 

--- a/translations/oe_content-hr.po
+++ b/translations/oe_content-hr.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "prosinca"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "sij"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "velj"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "ožu"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "tra"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "svi"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "lip"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "srp"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "kol"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "ruj"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "lis"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "stu"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "pro"
 

--- a/translations/oe_content-hu.po
+++ b/translations/oe_content-hu.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "december"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Jan"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Feb"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Már"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Ápr"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "Máj"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Jún"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Júl"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Aug"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "Szep"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "Okt"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Nov"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Dec"
 

--- a/translations/oe_content-it.po
+++ b/translations/oe_content-it.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "Dicembre"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Gen"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Feb"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Mar"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Apr"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "Mag"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Giu"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Lug"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Ago"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "Set"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "Ott"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Nov"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Dic"
 

--- a/translations/oe_content-lt.po
+++ b/translations/oe_content-lt.po
@@ -45,51 +45,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "Gruodis"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Sau"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Vas"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Kov"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Bal"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "Geg"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Bir"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Lie"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Rgp"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "Rgs"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "Spl"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Lap"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Grd"
 

--- a/translations/oe_content-lv.po
+++ b/translations/oe_content-lv.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "Decembris"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "janv."
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "febr."
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "marts"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "apr."
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "maijs"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "jūn."
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "jūl."
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "aug."
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "sept."
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "okt."
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "nov."
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "dec."
 

--- a/translations/oe_content-mt.po
+++ b/translations/oe_content-mt.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "Diċembru"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Jan"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Fra"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Mar"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Apr"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "Mej"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Ġun"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Lul"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Aww"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "Set"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "Ott"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Nov"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Diċ"
 

--- a/translations/oe_content-nl.po
+++ b/translations/oe_content-nl.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "december"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "jan"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "feb"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "mrt"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "apr"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "mei"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "jun"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "jul"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "aug"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "sep"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "okt"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "nov"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "dec"
 

--- a/translations/oe_content-pl.po
+++ b/translations/oe_content-pl.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "Grudzień"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Sty."
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Lut."
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Mar."
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Kw."
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "Maj"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Cze."
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Lip."
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Sie."
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "Wrz."
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "Paź."
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Lis."
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Gru."
 

--- a/translations/oe_content-pt-pt.po
+++ b/translations/oe_content-pt-pt.po
@@ -50,51 +50,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "Dezembro"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Jan"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Fev"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Mar"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Abr"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "Mai"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Jun"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Jul"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Ago"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "Set"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "Out"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Nov"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Dez"
 

--- a/translations/oe_content-ro.po
+++ b/translations/oe_content-ro.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "Decembrie"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "Ian"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "Feb"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "Mart"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "Apr"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "Mai"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "Iun"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "Iul"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "Aug"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "Sept"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "Oct"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "Nov"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "Dec"
 

--- a/translations/oe_content-sk.po
+++ b/translations/oe_content-sk.po
@@ -49,6 +49,42 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "december"
 
+msgid "Jan"
+msgstr "Jan"
+
+msgid "Feb"
+msgstr "Feb"
+
+msgid "Mar"
+msgstr "Mar"
+
+msgid "Apr"
+msgstr "Apr"
+
+msgid "May"
+msgstr "Máj"
+
+msgid "Jun"
+msgstr "Jún"
+
+msgid "Jul"
+msgstr "Júl"
+
+msgid "Aug"
+msgstr "Aug"
+
+msgid "Sep"
+msgstr "Sep"
+
+msgid "Oct"
+msgstr "Okt"
+
+msgid "Nov"
+msgstr "Nov"
+
+msgid "Dec"
+msgstr "Dec"
+
 msgid "Sunday"
 msgstr "nedeľa"
 

--- a/translations/oe_content-sl.po
+++ b/translations/oe_content-sl.po
@@ -49,6 +49,42 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "December"
 
+msgid "Jan"
+msgstr "jan"
+
+msgid "Feb"
+msgstr "feb"
+
+msgid "Mar"
+msgstr "mar"
+
+msgid "Apr"
+msgstr "apr"
+
+msgid "May"
+msgstr "maj"
+
+msgid "Jun"
+msgstr "jun"
+
+msgid "Jul"
+msgstr "jul"
+
+msgid "Aug"
+msgstr "avg"
+
+msgid "Sep"
+msgstr "sep"
+
+msgid "Oct"
+msgstr "okt"
+
+msgid "Nov"
+msgstr "nov"
+
+msgid "Dec"
+msgstr "dec"
+
 msgid "Sunday"
 msgstr "nedelja"
 

--- a/translations/oe_content-sv.po
+++ b/translations/oe_content-sv.po
@@ -49,51 +49,39 @@ msgctxt "Long month name"
 msgid "December"
 msgstr "december"
 
-msgctxt "Abbreviated month name"
 msgid "Jan"
 msgstr "jan"
 
-msgctxt "Abbreviated month name"
 msgid "Feb"
 msgstr "feb"
 
-msgctxt "Abbreviated month name"
 msgid "Mar"
 msgstr "mars"
 
-msgctxt "Abbreviated month name"
 msgid "Apr"
 msgstr "apr"
 
-msgctxt "Abbreviated month name"
 msgid "May"
 msgstr "maj"
 
-msgctxt "Abbreviated month name"
 msgid "Jun"
 msgstr "juni"
 
-msgctxt "Abbreviated month name"
 msgid "Jul"
 msgstr "juli"
 
-msgctxt "Abbreviated month name"
 msgid "Aug"
 msgstr "aug"
 
-msgctxt "Abbreviated month name"
 msgid "Sep"
 msgstr "sept"
 
-msgctxt "Abbreviated month name"
 msgid "Oct"
 msgstr "okt"
 
-msgctxt "Abbreviated month name"
 msgid "Nov"
 msgstr "nov"
 
-msgctxt "Abbreviated month name"
 msgid "Dec"
 msgstr "dec"
 


### PR DESCRIPTION
## EWPP-371

### Description

Remove non necessary context from translations.

### Change log

- Added:
- Changed: Remove non necessary context from translations.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

