### PR TITLE
EWPP-371: Lowercase month names in slovakian and slovenian.

### DIFF
--- a/translations/oe_content-sk.po
+++ b/translations/oe_content-sk.po
@@ -50,40 +50,40 @@ msgid "December"
 msgstr "december"
 
 msgid "Jan"
-msgstr "Jan"
+msgstr "jan"
 
 msgid "Feb"
-msgstr "Feb"
+msgstr "feb"
 
 msgid "Mar"
-msgstr "Mar"
+msgstr "mar"
 
 msgid "Apr"
-msgstr "Apr"
+msgstr "apr"
 
 msgid "May"
-msgstr "Máj"
+msgstr "máj"
 
 msgid "Jun"
-msgstr "Jún"
+msgstr "jún"
 
 msgid "Jul"
-msgstr "Júl"
+msgstr "júl"
 
 msgid "Aug"
-msgstr "Aug"
+msgstr "aug"
 
 msgid "Sep"
-msgstr "Sep"
+msgstr "sep"
 
 msgid "Oct"
-msgstr "Okt"
+msgstr "okt"
 
 msgid "Nov"
-msgstr "Nov"
+msgstr "nov"
 
 msgid "Dec"
-msgstr "Dec"
+msgstr "dec"
 
 msgid "Sunday"
 msgstr "nedeľa"

--- a/translations/oe_content-sl.po
+++ b/translations/oe_content-sl.po
@@ -3,51 +3,51 @@ msgstr ""
 
 msgctxt "Long month name"
 msgid "January"
-msgstr "Januar"
+msgstr "januar"
 
 msgctxt "Long month name"
 msgid "February"
-msgstr "Februar"
+msgstr "februar"
 
 msgctxt "Long month name"
 msgid "March"
-msgstr "Marec"
+msgstr "marec"
 
 msgctxt "Long month name"
 msgid "April"
-msgstr "April"
+msgstr "april"
 
 msgctxt "Long month name"
 msgid "May"
-msgstr "Maj"
+msgstr "maj"
 
 msgctxt "Long month name"
 msgid "June"
-msgstr "Junij"
+msgstr "junij"
 
 msgctxt "Long month name"
 msgid "July"
-msgstr "Julij"
+msgstr "julij"
 
 msgctxt "Long month name"
 msgid "August"
-msgstr "Avgust"
+msgstr "avgust"
 
 msgctxt "Long month name"
 msgid "September"
-msgstr "September"
+msgstr "september"
 
 msgctxt "Long month name"
 msgid "October"
-msgstr "Oktober"
+msgstr "oktober"
 
 msgctxt "Long month name"
 msgid "November"
-msgstr "November"
+msgstr "november"
 
 msgctxt "Long month name"
 msgid "December"
-msgstr "December"
+msgstr "december"
 
 msgid "Jan"
 msgstr "jan"


### PR DESCRIPTION
## EWPP-371

### Description

Lowercase month names in slovakian and slovenian.

### Change log

- Added:
- Changed: Lowercase month names in slovakian and slovenian.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

