### PR TITLE
EWPP-406: Use up to date patch for field_group.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         },
         "patches": {
             "drupal/field_group": {
-                "https://www.drupal.org/project/field_group/issues/2787179#comment-13467953": "https://www.drupal.org/files/issues/2020-02-17/2787179-highlight-html5-validation-45.patch"
+                "https://www.drupal.org/project/field_group/issues/2787179": "https://www.drupal.org/files/issues/2020-05-19/2787179-highlight-html5-validation-52.patch"
             },
             "drupal/address": {
                 "https://www.drupal.org/project/address/issues/2723917#comment-13844025": "https://www.drupal.org/files/issues/2020-10-02/address-multiple_value-2723917-13.patch"


### PR DESCRIPTION
## EWPP-406

### Description

Use up to date patch for field_group.

### Change log

- Added:
- Changed: Use up to date patch for field_group.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

