### PR TITLE
EWPP-443: Fixing Media PURL matcher dependency calculation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "drupal/entity_embed": "~1.0",
         "drupal/entity_reference_revisions": "~1.3",
         "drupal/field_group": "~3.0",
-        "drupal/inline_entity_form": "~1.0-rc7",
+        "drupal/inline_entity_form": "~1.0-rc8",
         "drupal/typed_link": "~1.1",
         "drupaltest/behat-traits": "dev-8.x-1.x",
         "drush/drush": "~9.0",
@@ -79,10 +79,6 @@
         "patches": {
             "drupal/field_group": {
                 "https://www.drupal.org/project/field_group/issues/2787179#comment-13467953": "https://www.drupal.org/files/issues/2020-02-17/2787179-highlight-html5-validation-45.patch"
-            },
-            "drupal/inline_entity_form": {
-                "https://www.drupal.org/project/inline_entity_form/issues/3162384": "https://www.drupal.org/files/issues/2020-08-13/fixed_duplicate_rows-3162384-16.patch",
-                "https://www.drupal.org/project/inline_entity_form/issues/2842744#comment-13775778": "https://www.drupal.org/files/issues/2020-08-04/inline_entity_form-no_label_required_field_with_no_entries-2842744-27-D8.patch"
             },
             "drupal/address": {
                 "https://www.drupal.org/project/address/issues/2723917#comment-13844025": "https://www.drupal.org/files/issues/2020-10-02/address-multiple_value-2723917-13.patch"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/core": "^8.8",
+        "drupal/core": "^8.8.2",
         "drupal/linkit": "~5.0-beta8",
         "drupal/maxlength": "~1.0@beta",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",

--- a/modules/oe_content_event/README.md
+++ b/modules/oe_content_event/README.md
@@ -12,7 +12,7 @@ Before enabling this module, make sure that the following modules are present in
     "drupal/composite_reference": "~1.0-alpha2",
     "drupal/entity_reference_revisions": "~1.3",
     "drupal/field_group": "~3.0",
-    "drupal/inline_entity_form": "~1.0-rc7",
+    "drupal/inline_entity_form": "~1.0-rc8",
     "drupal/typed_link": "~1.1",
     "openeuropa/oe_corporate_countries": "~1.0.0-beta1"
 }
@@ -25,17 +25,6 @@ The `field_group` module requires the following patches to be applied:
     "drupal/field_group": {
         "https://www.drupal.org/project/field_group/issues/2787179#comment-13467953": "https://www.drupal.org/files/issues/2020-02-17/2787179-highlight-html5-validation-45.patch",
         "https://www.drupal.org/node/3072732": "https://www.drupal.org/files/issues/2019-08-06/3072732-6.patch"
-    }
-}
-```
-
-The `inline_entity_form` module requires the following patches to be applied:
-
-```json
-"patches": {
-    "drupal/inline_entity_form": {
-        "https://www.drupal.org/project/inline_entity_form/issues/3162384": "https://www.drupal.org/files/issues/2020-08-13/fixed_duplicate_rows-3162384-16.patch",
-        "https://www.drupal.org/project/inline_entity_form/issues/2842744#comment-13775778": "https://www.drupal.org/files/issues/2020-08-04/inline_entity_form-no_label_required_field_with_no_entries-2842744-27-D8.patch"
     }
 }
 ```

--- a/modules/oe_content_news/README.md
+++ b/modules/oe_content_news/README.md
@@ -13,7 +13,7 @@ Before enabling this module, make sure the following modules are present in your
     "drupal/field_group": "~3.0",
     "drupal/composite_reference": "~1.0-alpha2",
     "drupal/entity_reference_revisions": "~1.3",
-    "drupal/inline_entity_form": "~1.3"
+    "drupal/inline_entity_form": "~1.0-rc8",
 }
 ```
 
@@ -23,16 +23,6 @@ The `field_group` module requires the following patches to be applied:
 "patches": {
     "drupal/field_group": {
         "https://www.drupal.org/project/field_group/issues/2787179#comment-13467953": "https://www.drupal.org/files/issues/2020-02-17/2787179-highlight-html5-validation-45.patch"
-    }
-}
-```
-The `inline_entity_form` module requires the following patches to be applied:
-
-```json
-"patches": {
-    "drupal/inline_entity_form": {
-        "https://www.drupal.org/project/inline_entity_form/issues/3162384": "https://www.drupal.org/files/issues/2020-08-13/fixed_duplicate_rows-3162384-16.patch",
-        "https://www.drupal.org/project/inline_entity_form/issues/2842744#comment-13775778": "https://www.drupal.org/files/issues/2020-08-04/inline_entity_form-no_label_required_field_with_no_entries-2842744-27-D8.patch"
     }
 }
 ```

--- a/modules/oe_content_organisation/README.md
+++ b/modules/oe_content_organisation/README.md
@@ -12,7 +12,7 @@ Before enabling this module, make sure that the following modules are present in
     "drupal/composite_reference": "~1.0-alpha2",
     "drupal/entity_reference_revisions": "~1.3",
     "drupal/field_group": "~3.0",
-    "drupal/inline_entity_form": "~1.0-rc7"
+    "drupal/inline_entity_form": "~1.0-rc9"
 }
 ```
 
@@ -23,16 +23,6 @@ The `field_group` module requires the following patches to be applied:
     "drupal/field_group": {
         "https://www.drupal.org/project/field_group/issues/2787179#comment-13467953": "https://www.drupal.org/files/issues/2020-02-17/2787179-highlight-html5-validation-45.patch",
         "https://www.drupal.org/node/3072732": "https://www.drupal.org/files/issues/2019-08-06/3072732-6.patch"
-    }
-}
-```
-
-The `inline_entity_form` module requires the following patches to be applied:
-
-```json
-"patches": {
-    "drupal/inline_entity_form": {
-        "https://www.drupal.org/project/inline_entity_form/issues/3162384": "https://www.drupal.org/files/issues/2020-08-13/fixed_duplicate_rows-3162384-16.patch"
     }
 }
 ```

--- a/modules/oe_content_organisation/README.md
+++ b/modules/oe_content_organisation/README.md
@@ -12,7 +12,7 @@ Before enabling this module, make sure that the following modules are present in
     "drupal/composite_reference": "~1.0-alpha2",
     "drupal/entity_reference_revisions": "~1.3",
     "drupal/field_group": "~3.0",
-    "drupal/inline_entity_form": "~1.0-rc9"
+    "drupal/inline_entity_form": "~1.0-rc8"
 }
 ```
 

--- a/modules/oe_content_persistent/src/Plugin/Linkit/Matcher/MediaPurlMatcher.php
+++ b/modules/oe_content_persistent/src/Plugin/Linkit/Matcher/MediaPurlMatcher.php
@@ -105,7 +105,7 @@ class MediaPurlMatcher extends EntityMatcher {
     ];
     if ($this->configuration['thumbnail']['show_thumbnail']) {
       $dependencies['module'][] = 'image';
-      $dependencies['config'][] = 'image.style.' . $this->configuration['images']['thumbnail_image_style'];
+      $dependencies['config'][] = 'image.style.' . $this->configuration['thumbnail']['thumbnail_image_style'];
     }
     return $dependencies;
   }

--- a/modules/oe_content_project/README.md
+++ b/modules/oe_content_project/README.md
@@ -12,7 +12,7 @@ Before enabling this module, make sure that the following modules are present in
     "drupal/composite_reference": "~1.0@alpha",
     "drupal/entity_reference_revisions": "~1.3",
     "drupal/field_group": "~3.0",
-    "drupal/inline_entity_form": "~1.0-rc5",
+    "drupal/inline_entity_form": "~1.0-rc8",
 }
 ```
 
@@ -23,16 +23,6 @@ The `field_group` module requires the following patches to be applied:
     "drupal/field_group": {
         "https://www.drupal.org/project/field_group/issues/2787179#comment-13467953": "https://www.drupal.org/files/issues/2020-02-17/2787179-highlight-html5-validation-45.patch"
     },
-}
-```
-
-The `inline_entity_form` module requires the following patches to be applied:
-
-```json
-"patches": {
-    "drupal/inline_entity_form": {
-        "https://www.drupal.org/project/inline_entity_form/issues/2842744#comment-13775778": "https://www.drupal.org/files/issues/2020-08-04/inline_entity_form-no_label_required_field_with_no_entries-2842744-27-D8.patch"
-    }
 }
 ```
 


### PR DESCRIPTION
This PR cherry-picks that specific commit from another branch, so that it can be released as a patch release in 1.11.1. The branch release-1.11.x has been branched off the 1.11.0 tag.