### PR TITLE
EWPP-615: Set default content owner values when creating new content

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ overriding the language.content_setting configuration.
 This module provides a sub-module (oe_content_entity) with a set of Corporate content entities to be used.
 Check out the [README](/modules/oe_content_entity/README.md) of the module.
 
-The module sets the "Content Owner" field value automatically when new content is created. The initial "Content Owner" field value is set in the "Basic site settings" administrative page. This functionality is available only if [OpenEuropa Corporate Site Information](https://github.com/openeuropa/oe_corporate_site_info) is enabled.
+The module sets the "Content Owner" field value automatically when new content is created. The default "Content Owner" field value can be set in the "Basic site settings" administrative page. This functionality is available only if [OpenEuropa Corporate Site Information](https://github.com/openeuropa/oe_corporate_site_info) is enabled.
 
 **Table of contents:**
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ overriding the language.content_setting configuration.
 This module provides a sub-module (oe_content_entity) with a set of Corporate content entities to be used.
 Check out the [README](/modules/oe_content_entity/README.md) of the module.
 
+The module sets the "Content Owner" field value automatically when new content is created. The initial "Content Owner" field value is set in the "Basic site settings" administrative page. This functionality is available only if [OpenEuropa Corporate Site Information](https://github.com/openeuropa/oe_corporate_site_info) is enabled.
+
 **Table of contents:**
 
 - [Requirements](#requirements)

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "openeuropa/code-review": "~1.5.0",
         "openeuropa/drupal-core-require-dev": "^8.7",
         "openeuropa/oe_corporate_countries": "~1.0.0-beta1",
+        "openeuropa/oe_corporate_site_info": "^0.1.0",
         "openeuropa/oe_link_lists": "~0.5.0",
         "openeuropa/oe_multilingual": "~1.5",
         "openeuropa/oe_time_caching": "^1.0.0",
@@ -97,6 +98,9 @@
             },
             "openeuropa/oe_media": {
                 "latest-master": "https://github.com/openeuropa/oe_media/compare/1.10.1...master.diff"
+            },
+            "openeuropa/oe_corporate_site_info": {
+                "EWPP-615": "https://github.com/openeuropa/oe_corporate_site_info/compare/master...EWPP-615.diff"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
                 "latest-master": "https://github.com/openeuropa/oe_media/compare/1.10.1...master.diff"
             },
             "openeuropa/oe_corporate_site_info": {
-                "EWPP-615": "https://github.com/openeuropa/oe_corporate_site_info/compare/master...EWPP-615.diff"
+                "latest-master": "https://github.com/openeuropa/oe_corporate_site_info/compare/0.1.0..master.diff"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "symfony/dom-crawler": "~3.4"
     },
     "_readme": [
-        "We explicitly require drupal/inline_entity_form version rc8 or higher as it contains necessary bug fixes."
+        "We explicitly require drupal/inline_entity_form version rc8 or higher as it contains necessary bug fixes.",
+        "We apply the changes from \"openeuropa/oe_corporate_site_info\" as a patch until they are merged in the master branch."
     ],
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,13 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
+        "php": ">=7.2",
         "drupal/core": "^8.8.2",
         "drupal/linkit": "~5.0-beta8",
         "drupal/maxlength": "~1.0@beta",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",
-        "openeuropa/rdf_skos": "~0.11",
         "openeuropa/oe_media": "~1.10.1",
-        "php": ">=7.2"
+        "openeuropa/rdf_skos": "~0.11"
     },
     "require-dev": {
         "composer/installers": "~1.5",
@@ -37,7 +37,7 @@
         "openeuropa/code-review": "~1.5.0",
         "openeuropa/drupal-core-require-dev": "^8.7",
         "openeuropa/oe_corporate_countries": "~1.0.0-beta1",
-        "openeuropa/oe_corporate_site_info": "^0.1.0",
+        "openeuropa/oe_corporate_site_info": "dev-master",
         "openeuropa/oe_link_lists": "~0.5.0",
         "openeuropa/oe_multilingual": "~1.5",
         "openeuropa/oe_time_caching": "^1.0.0",
@@ -99,9 +99,6 @@
             },
             "openeuropa/oe_media": {
                 "latest-master": "https://github.com/openeuropa/oe_media/compare/1.10.1...master.diff"
-            },
-            "openeuropa/oe_corporate_site_info": {
-                "latest-master": "https://github.com/openeuropa/oe_corporate_site_info/compare/0.1.0..master.diff"
             }
         }
     },

--- a/oe_content.module
+++ b/oe_content.module
@@ -114,7 +114,7 @@ function oe_content_locale_translation_projects_alter(&$projects) {
  * Implements hook_ENTITY_TYPE_prepare_form().
  */
 function oe_content_node_prepare_form(EntityInterface $entity, $operation, FormStateInterface $form_state) {
-  /** @var \Drupal\node\Entity\Node $entity */
+  /** @var \Drupal\node\NodeInterface $entity */
   if ($entity->isNew() === FALSE) {
     return;
   }

--- a/oe_content.module
+++ b/oe_content.module
@@ -11,6 +11,8 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\link\LinkItemInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Implements hook_entity_base_field_info().
@@ -106,3 +108,38 @@ function oe_content_entity_base_field_info(EntityTypeInterface $entity_type) {
 function oe_content_locale_translation_projects_alter(&$projects) {
   $projects['oe_content']['info']['interface translation server pattern'] = drupal_get_path('module', 'oe_content') . '/translations/%project-%language.po';
 }
+
+
+/**
+ * Implements hook_ENTITY_TYPE_prepare_form().
+ */
+function oe_content_node_prepare_form(EntityInterface $entity, $operation, FormStateInterface $form_state) {
+  /** @var \Drupal\node\Entity\Node $entity */
+  if ($entity->isNew() === FALSE) {
+    return;
+  }
+
+  if ($entity->hasField('oe_content_content_owner') === FALSE) {
+    return;
+  }
+
+  /** @var \Drupal\Core\Extension\ModuleHandlerInterface $module_handler */
+  $module_handler = \Drupal::service('module_handler');
+  if ($module_handler->moduleExists('oe_corporate_site_info') === FALSE) {
+    return;
+  }
+
+  /** @var \Drupal\oe_corporate_site_info\SiteInformationInterface $site_information */
+  $site_information = \Drupal::service('oe_corporate_site_info.site_information');
+  if (!$site_information->hasContentOwners()) {
+    // No content owner(s) defined.
+    return;
+  }
+
+  $content_owners = $site_information->getContentOwners();
+
+  if (!empty($content_owners)) {
+    $entity->set('oe_content_content_owner', array_values($content_owners));
+  }
+}
+

--- a/oe_content.module
+++ b/oe_content.module
@@ -123,20 +123,18 @@ function oe_content_node_prepare_form(EntityInterface $entity, $operation, FormS
     return;
   }
 
-  /** @var \Drupal\Core\Extension\ModuleHandlerInterface $module_handler */
-  $module_handler = \Drupal::service('module_handler');
-  if ($module_handler->moduleExists('oe_corporate_site_info') === FALSE) {
+  if (\Drupal::service('module_handler')->moduleExists('oe_corporate_site_info') === FALSE) {
     return;
   }
 
   /** @var \Drupal\oe_corporate_site_info\SiteInformationInterface $site_information */
   $site_information = \Drupal::service('oe_corporate_site_info.site_information');
-  if (!$site_information->hasContentOwners()) {
+  if (!$site_information->hasDefaultContentOwners()) {
     // No content owner(s) defined.
     return;
   }
 
-  $content_owners = $site_information->getContentOwners();
+  $content_owners = $site_information->getDefaultContentOwners();
 
   if (!empty($content_owners)) {
     $entity->set('oe_content_content_owner', array_values($content_owners));

--- a/tests/FunctionalJavascript/DefaultContentOwnerTest.php
+++ b/tests/FunctionalJavascript/DefaultContentOwnerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_content\FunctionalJavascript;
+
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\Tests\rdf_entity\Traits\RdfDatabaseConnectionTrait;
+
+/**
+ * Tests the default content owner field values.
+ */
+class DefaultContentOwnerTest extends WebDriverTestBase {
+
+  use RdfDatabaseConnectionTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'oe_content',
+    'oe_content_page',
+    'oe_corporate_site_info',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->setUpSparql();
+
+    $this->container->get('config.factory')->getEditable('oe_corporate_site_info.settings')
+      ->set('content_owners', [
+        'http://publications.europa.eu/resource/authority/corporate-body/AGRI',
+        'http://publications.europa.eu/resource/authority/corporate-body/BUDG',
+      ])
+      ->save();
+  }
+
+  /**
+   * Tests the default content owner values on new nodes.
+   */
+  public function testDefaultContentOwnerValues() {
+    $user = $this->drupalCreateUser([
+      'access content',
+      'create oe_page content',
+      'view published skos concept entities',
+    ]);
+
+    $this->drupalLogin($user);
+
+    $this->drupalGet('/node/add/oe_page');
+
+    $assert_session = $this->assertSession();
+    $assert_session->fieldValueEquals('oe_content_content_owner[0][target_id]', 'Directorate-General for Agriculture and Rural Development (http://publications.europa.eu/resource/authority/corporate-body/AGRI)');
+    $assert_session->fieldValueEquals('oe_content_content_owner[1][target_id]', 'Directorate-General for Budget (http://publications.europa.eu/resource/authority/corporate-body/BUDG)');
+  }
+
+}

--- a/tests/FunctionalJavascript/DefaultContentOwnerTest.php
+++ b/tests/FunctionalJavascript/DefaultContentOwnerTest.php
@@ -58,4 +58,48 @@ class DefaultContentOwnerTest extends WebDriverTestBase {
     $assert_session->fieldValueEquals('oe_content_content_owner[1][target_id]', 'Directorate-General for Budget (http://publications.europa.eu/resource/authority/corporate-body/BUDG)');
   }
 
+  /**
+   * No default content owner is set.
+   *
+   * Tests that no default content owner is set in the node
+   * form if not set as site information.
+   */
+  public function testUnsetDefaultContentOwnerValues() {
+    $this->container->get('config.factory')->getEditable('oe_corporate_site_info.settings')
+      ->set('content_owners', [])
+      ->save();
+
+    $user = $this->drupalCreateUser([
+      'access content',
+      'create oe_page content',
+    ]);
+
+    $this->drupalLogin($user);
+
+    $this->drupalGet('/node/add/oe_page');
+
+    $this->assertSession()->fieldValueEquals('oe_content_content_owner[0][target_id]', '');
+  }
+
+  /**
+   * Module "Corporate Site Information" not enabled.
+   *
+   * Tests that uninstalling the "Corporate Site Information" module
+   * has no effect on the node form.
+   */
+  public function testCorporateSiteInfoNotEnabled() {
+    $this->container->get('module_installer')->uninstall(['oe_corporate_site_info']);
+
+    $user = $this->drupalCreateUser([
+      'access content',
+      'create oe_page content',
+    ]);
+
+    $this->drupalLogin($user);
+
+    $this->drupalGet('/node/add/oe_page');
+
+    $this->assertSession()->fieldValueEquals('oe_content_content_owner[0][target_id]', '');
+  }
+
 }

--- a/tests/FunctionalJavascript/DefaultContentOwnerTest.php
+++ b/tests/FunctionalJavascript/DefaultContentOwnerTest.php
@@ -30,19 +30,20 @@ class DefaultContentOwnerTest extends WebDriverTestBase {
     parent::setUp();
 
     $this->setUpSparql();
+  }
 
+  /**
+   * Tests the content owner values on new nodes.
+   */
+  public function testContentOwnerValues() {
+    // Set the default content owner values.
     $this->container->get('config.factory')->getEditable('oe_corporate_site_info.settings')
       ->set('content_owners', [
         'http://publications.europa.eu/resource/authority/corporate-body/AGRI',
         'http://publications.europa.eu/resource/authority/corporate-body/BUDG',
       ])
       ->save();
-  }
 
-  /**
-   * Tests the default content owner values on new nodes.
-   */
-  public function testDefaultContentOwnerValues() {
     $user = $this->drupalCreateUser([
       'access content',
       'create oe_page content',
@@ -54,52 +55,28 @@ class DefaultContentOwnerTest extends WebDriverTestBase {
     $this->drupalGet('/node/add/oe_page');
 
     $assert_session = $this->assertSession();
+
+    // Assert that default owner values are set when creating a new node.
     $assert_session->fieldValueEquals('oe_content_content_owner[0][target_id]', 'Directorate-General for Agriculture and Rural Development (http://publications.europa.eu/resource/authority/corporate-body/AGRI)');
     $assert_session->fieldValueEquals('oe_content_content_owner[1][target_id]', 'Directorate-General for Budget (http://publications.europa.eu/resource/authority/corporate-body/BUDG)');
-  }
 
-  /**
-   * No default content owner is set.
-   *
-   * Tests that no default content owner is set in the node
-   * form if not set as site information.
-   */
-  public function testUnsetDefaultContentOwnerValues() {
+    // Unset the default content owner values.
     $this->container->get('config.factory')->getEditable('oe_corporate_site_info.settings')
       ->set('content_owners', [])
       ->save();
 
-    $user = $this->drupalCreateUser([
-      'access content',
-      'create oe_page content',
-    ]);
-
-    $this->drupalLogin($user);
-
     $this->drupalGet('/node/add/oe_page');
 
-    $this->assertSession()->fieldValueEquals('oe_content_content_owner[0][target_id]', '');
-  }
+    // Assert that no default content owners are set when creating a new node.
+    $assert_session->fieldValueEquals('oe_content_content_owner[0][target_id]', '');
 
-  /**
-   * Module "Corporate Site Information" not enabled.
-   *
-   * Tests that uninstalling the "Corporate Site Information" module
-   * has no effect on the node form.
-   */
-  public function testCorporateSiteInfoNotEnabled() {
+    // Uninstall the "Corporate Site Information" module.
     $this->container->get('module_installer')->uninstall(['oe_corporate_site_info']);
 
-    $user = $this->drupalCreateUser([
-      'access content',
-      'create oe_page content',
-    ]);
-
-    $this->drupalLogin($user);
-
     $this->drupalGet('/node/add/oe_page');
 
-    $this->assertSession()->fieldValueEquals('oe_content_content_owner[0][target_id]', '');
+    // Assert that the Content Owner form fields are displayed.
+    $assert_session->fieldValueEquals('oe_content_content_owner[0][target_id]', '');
   }
 
 }

--- a/tests/FunctionalJavascript/DefaultContentOwnerTest.php
+++ b/tests/FunctionalJavascript/DefaultContentOwnerTest.php
@@ -17,7 +17,7 @@ class DefaultContentOwnerTest extends WebDriverTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'oe_content',
     'oe_content_page',
     'oe_corporate_site_info',


### PR DESCRIPTION
## OPENEUROPA-615

### Description

Set the site-wide Content Owner value(s) as default value(s) in the new content node forms.

### Change log

- Added: new hook_ENTITY_TYPE_prepare_form() and a functional test
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

