### PR TITLE
EWPP-1031: Use role qualifier vocabulary

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   web:
-    image: fpfis/httpd-php-dev:7.3
+    image: fpfis/httpd-php-dev@sha256:bd146bddf43bda78720dbe8e4e8da563344d4551f372b572b3d039e96e7371f4
     working_dir: /var/www/html
     ports:
       - 8080:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   web:
-    image: fpfis/httpd-php-dev@sha256:bd146bddf43bda78720dbe8e4e8da563344d4551f372b572b3d039e96e7371f4
+    image: fpfis/httpd-php-dev:7.3
     working_dir: /var/www/html
     ports:
       - 8080:8080

--- a/modules/oe_content_person/config/install/field.field.oe_person_job.oe_default.oe_role_reference.yml
+++ b/modules/oe_content_person/config/install/field.field.oe_person_job.oe_default.oe_role_reference.yml
@@ -24,11 +24,11 @@ settings:
       field: _none
     auto_create: false
     concept_schemes:
-      - 'http://publications.europa.eu/resource/authority/role'
+      - 'http://publications.europa.eu/resource/authority/role-qualifier'
     field:
       field_name: oe_role_reference
       entity_type: oe_person_job
       bundle: oe_default
       concept_schemes:
-        - 'http://publications.europa.eu/resource/authority/role'
+        - 'http://publications.europa.eu/resource/authority/role-qualifier'
 field_type: skos_concept_entity_reference

--- a/modules/oe_content_person/oe_content_person.install
+++ b/modules/oe_content_person/oe_content_person.install
@@ -21,7 +21,7 @@ function oe_content_person_install() {
 
   $graphs = [
     'human-sex' => 'http://publications.europa.eu/resource/dataset/human-sex',
-    'role' => 'http://publications.europa.eu/resource/dataset/role',
+    'role-qualifier' => 'http://publications.europa.eu/resource/dataset/role-qualifier',
   ];
   \Drupal::service('rdf_skos.skos_graph_configurator')->addGraphs($graphs);
 

--- a/modules/oe_content_person/oe_content_person.post_update.php
+++ b/modules/oe_content_person/oe_content_person.post_update.php
@@ -31,3 +31,23 @@ function oe_content_person_post_update_20001(): void {
   $field_storage->set('settings', $settings);
   $field_storage->save();
 }
+
+/**
+ * Use role qualifier vocabulary on person job role.
+ */
+function oe_content_person_post_update_20002(): void {
+  // Add the new role qualifier vocabulary.
+  $graphs = [
+    'role-qualifier' => 'http://publications.europa.eu/resource/dataset/role-qualifier',
+  ];
+  \Drupal::service('rdf_skos.skos_graph_configurator')->addGraphs($graphs);
+
+  // Use the new vocabulary on the role reference field.
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $field_storage = $entity_type_manager->getStorage('field_config')->load('oe_person_job.oe_default.oe_role_reference');
+  $settings = $field_storage->get('settings');
+  $settings['handler_settings']['concept_schemes'] = ['http://publications.europa.eu/resource/authority/role-qualifier'];
+  $settings['handler_settings']['field']['concept_schemes'] = ['http://publications.europa.eu/resource/authority/role-qualifier'];
+  $field_storage->set('settings', $settings);
+  $field_storage->save();
+}

--- a/modules/oe_content_person/oe_content_person.post_update.php
+++ b/modules/oe_content_person/oe_content_person.post_update.php
@@ -43,8 +43,7 @@ function oe_content_person_post_update_20002(): void {
   \Drupal::service('rdf_skos.skos_graph_configurator')->addGraphs($graphs);
 
   // Use the new vocabulary on the role reference field.
-  $entity_type_manager = \Drupal::entityTypeManager();
-  $field_storage = $entity_type_manager->getStorage('field_config')->load('oe_person_job.oe_default.oe_role_reference');
+  $field_storage = \Drupal::entityTypeManager()->getStorage('field_config')->load('oe_person_job.oe_default.oe_role_reference');
   $settings = $field_storage->get('settings');
   $settings['handler_settings']['concept_schemes'] = ['http://publications.europa.eu/resource/authority/role-qualifier'];
   $settings['handler_settings']['field']['concept_schemes'] = ['http://publications.europa.eu/resource/authority/role-qualifier'];

--- a/modules/oe_content_person/tests/src/FunctionalJavascript/PersonEntityTest.php
+++ b/modules/oe_content_person/tests/src/FunctionalJavascript/PersonEntityTest.php
@@ -75,7 +75,7 @@ class PersonEntityTest extends WebDriverTestBase {
 
     // Fill in the job fields, they should not be saved after
     // we change the type to non-eu.
-    $this->getSession()->getPage()->fillField('oe_person_jobs[form][0][oe_role_reference][0][target_id]', 'Addressee (http://publications.europa.eu/resource/authority/role/ADDRESSEE)');
+    $this->getSession()->getPage()->fillField('oe_person_jobs[form][0][oe_role_reference][0][target_id]', 'Advisor (http://publications.europa.eu/resource/authority/role-qualifier/ADVIS)');
 
     // Change the person type to non-eu
     // and assert the available fields have changed.
@@ -139,7 +139,7 @@ class PersonEntityTest extends WebDriverTestBase {
     $this->assertEmpty($this->getSession()->getPage()->findField('oe_person_jobs[form][inline_entity_form][entities][0][form][oe_role_reference][0][target_id]')->getValue());
 
     // Update the job with a reference role and set it to be an acting role.
-    $this->getSession()->getPage()->fillField('oe_person_jobs[form][inline_entity_form][entities][0][form][oe_role_reference][0][target_id]', 'Addressee (http://publications.europa.eu/resource/authority/role/ADDRESSEE)');
+    $this->getSession()->getPage()->fillField('oe_person_jobs[form][inline_entity_form][entities][0][form][oe_role_reference][0][target_id]', 'Advisor (http://publications.europa.eu/resource/authority/role-qualifier/ADVIS)');
     $this->getSession()->getPage()->checkField('oe_person_jobs[form][inline_entity_form][entities][0][form][oe_acting][value]');
 
     // Save the person and assert it was updated.
@@ -151,7 +151,7 @@ class PersonEntityTest extends WebDriverTestBase {
     $job_region = $this->getSession()->getPage()->find('css', '#edit-oe-person-jobs-wrapper');
     $job_region->pressButton('Edit');
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->assertSession()->fieldValueEquals('oe_person_jobs[form][inline_entity_form][entities][0][form][oe_role_reference][0][target_id]', 'Addressee (http://publications.europa.eu/resource/authority/role/ADDRESSEE)');
+    $this->assertSession()->fieldValueEquals('oe_person_jobs[form][inline_entity_form][entities][0][form][oe_role_reference][0][target_id]', 'Advisor (http://publications.europa.eu/resource/authority/role-qualifier/ADVIS)');
 
     // Change the type of person to non-eu and assert
     // the old job type is no longer stored.
@@ -173,7 +173,7 @@ class PersonEntityTest extends WebDriverTestBase {
     // Change the person type to eu and assert the first job's role
     // is kept and the new job's fields are updated.
     $this->getSession()->getPage()->selectFieldOption('oe_person_type', 'eu');
-    $this->assertSession()->fieldValueEquals('oe_person_jobs[form][inline_entity_form][entities][0][form][oe_role_reference][0][target_id]', 'Addressee (http://publications.europa.eu/resource/authority/role/ADDRESSEE)');
+    $this->assertSession()->fieldValueEquals('oe_person_jobs[form][inline_entity_form][entities][0][form][oe_role_reference][0][target_id]', 'Advisor (http://publications.europa.eu/resource/authority/role-qualifier/ADVIS)');
     $this->assertTrue($this->getSession()->getPage()->findField('oe_person_jobs[form][1][oe_role_reference][0][target_id]')->isVisible());
     $this->assertTrue($this->getSession()->getPage()->findField('oe_person_jobs[form][1][oe_acting][value]')->isVisible());
     $this->assertTrue($this->getSession()->getPage()->findField('oe_person_jobs[form][1][oe_description][0][value]')->isVisible());

--- a/tests/features/person.feature
+++ b/tests/features/person.feature
@@ -1,4 +1,4 @@
-@api
+@api @test
 Feature: Person content creation
   In order to have "Person" on the site
   As an editor
@@ -133,7 +133,7 @@ Feature: Person content creation
     # Jobs field.
     And I press "Add new person job"
     And I wait for AJAX to finish
-    And I fill in "first" person job role reference field with "Advocate-General"
+    And I fill in "first" person job role reference field with "Advisor"
     And I fill in "Responsibilities assigned to the job" with "Responsibilities text"
     And I check "Acting role"
     And I press "Save"
@@ -183,21 +183,21 @@ Feature: Person content creation
     # Document references are shown.
     And I should see "document2.pdf"
     And I should see "Publication node in Person"
-    And I should see the text "Advocate-General"
+    And I should see the text "Advisor"
     And I should see the text "Responsibilities text"
     And the "Acting role field" element should contain "On"
 
     When I click "Edit"
     And I select "Person not part of the EU institutions" from "What type of person are you adding?"
     And I press "Save"
-    Then I should see "The role \"(Acting) Advocate-General\" is not compatible with the type of person currently selected. Please edit the related job entry and fix its role accordingly."
+    Then I should see "The role \"(Acting) Advisor\" is not compatible with the type of person currently selected. Please edit the related job entry and fix its role accordingly."
     When I fill in "Organisation" with "Organisation demo page"
     And I press "Edit" in the "Person jobs" region
     And I fill in "Role" with "Person job role"
     And I press "Save"
     Then I should see "Organisation demo page"
     And I should not see the link "European Patent Office"
-    And I should not see "Advocate-General"
+    And I should not see "Advisor"
     And I should see "Person job role"
     Then I should not see "Acting role"
 
@@ -233,7 +233,7 @@ Feature: Person content creation
       | Name | A general contact |
     And the following Default "Person job" sub-entity:
       | Name             | Default person job 1  |
-      | Role reference   | Advocate-General      |
+      | Role reference   | Advisor      |
       | Acting role      | Yes                   |
       | Responsibilities | Responsibilities text |
     And the following document:
@@ -255,7 +255,7 @@ Feature: Person content creation
     When I am visiting the "First Last" content
     Then I should see "First Last"
     And I should see "A general contact"
-    And I should see "Advocate-General"
+    And I should see "Advisor"
     And I should see "sample.pdf"
 
     When I am logged in as a user with the "create oe_person content, access content, edit any oe_person content, view published skos concept entities, manage corporate content entities" permission
@@ -266,7 +266,7 @@ Feature: Person content creation
     When I press "Remove" in the "Person contacts" region
     And I wait for AJAX to finish
     And I press "Remove" in the "Person jobs" region
-    Then I should see "Are you sure you want to remove (Acting) Advocate-General?"
+    Then I should see "Are you sure you want to remove (Acting) Advisor?"
     When I press "Remove" in the "Person jobs" region
     And I wait for AJAX to finish
     And I press "Remove" in the "Person documents" region
@@ -276,7 +276,7 @@ Feature: Person content creation
     And I press "Save"
     Then I should see "Person First Last has been updated."
     And I should not see "A general contact"
-    And I should not see "Advocate-General"
+    And I should not see "Advisor"
     And I should not see "sample.pdf"
     And the General Contact entity with title "A general contact" exists
     And the "Person job" sub-entity with title "Default person job 1" exists

--- a/tests/features/person.feature
+++ b/tests/features/person.feature
@@ -1,4 +1,4 @@
-@api @test
+@api
 Feature: Person content creation
   In order to have "Person" on the site
   As an editor


### PR DESCRIPTION
## EWPP-1031: Use role qualifier vocabulary

### Description

Use role qualifier vocabulary in the person job role field.

### Change log

- Added:
- Changed: Use role qualifier vocabulary in the person job role field.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

