### PR TITLE
EWPP-1257: Fix the triple store image to 1.14 to avoid the Provisional data terms.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,9 @@ services:
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
   sparql:
-    image: registry.fpfis.eu/openeuropa/triple-store-dev
+    # Temporarily fix the triple store version to avoid "Provisional data" terms.
+    # @todo: Use the latest release once a solution for the "Provisional data" terms is implemented.
+    image: registry.fpfis.eu/openeuropa/triple-store-dev:1.14.0
     pull: true
     environment:
       - SPARQL_UPDATE=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       XDEBUG_MODE: "develop, debug"
       PHP_IDE_CONFIG: "serverName=Docker"
       # Enable step debugging for all PHP request. See ./README.md#step-debugging for more information.
-      # XDEBUG_SESSION: 1
+      #XDEBUG_SESSION: 1
   mysql:
     image: percona/percona-server:5.7
     command: --innodb-log-file-size=1G --max_allowed_packet=1G --innodb-buffer-pool-size=512M --wait_timeout=3000 --net_write_timeout=3000 --log_error_verbosity=3
@@ -23,7 +23,9 @@ services:
 #    ports:
 #      - 3306:3306
   sparql:
-    image: openeuropa/triple-store-dev
+    # Temporarily fix the triple store version to avoid "Provisional data" terms.
+    # @todo: Use the latest release once a solution for the "Provisional data" terms is implemented.
+    image: openeuropa/triple-store-dev:1.14.0
     environment:
     - SPARQL_UPDATE=true
     - DBA_PASSWORD=dba


### PR DESCRIPTION

## EWPP-1257

### Description

The 1.15 version of triple store introduced "Provisional data" terms that pollute the related drupal selects. We fix the version to 1.14 for now until a solultion is devised.

### Change log

- Added:
- Changed: Fixed triple store to 1.14
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

