### PR TITLE
EWPP-2607: Fix maxlength_js_enforce class not applied.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "drupal/entity_reference_revisions": "^1.8",
         "drupal/field_group": "~3.2",
         "drupal/inline_entity_form": "^1.0-rc12",
-        "drupal/sparql_entity_storage": "1.0.0-alpha10",
+        "drupal/sparql_entity_storage": "^1.0.0-alpha10",
         "drupal/typed_link": "^2.0",
         "drupal/token": "^1.10",
         "drupaltest/behat-traits": "^0.3",

--- a/composer.json
+++ b/composer.json
@@ -95,6 +95,9 @@
             "drupal/inline_entity_form": {
                 "https://www.drupal.org/project/inline_entity_form/issues/2875716": "https://www.drupal.org/files/issues/2022-07-20/ief_removed_references_2875716-104.patch"
             },
+            "drupal/maxlength": {
+                "https://www.drupal.org/project/maxlength/issues/3310421": "https://www.drupal.org/files/issues/2022-09-26/maxlength_js_enforce_3310421-2_0_0-rc1-16.patch"
+            },
             "drupal/typed_link": {
                 "https://www.drupal.org/project/typed_link/issues/3263477": "https://www.drupal.org/files/issues/2022-02-09/typed_link_constraints-3263477-2.patch"
             }

--- a/modules/oe_content_call_proposals/config/install/core.entity_form_display.node.oe_call_proposals.default.yml
+++ b/modules/oe_content_call_proposals/config/install/core.entity_form_display.node.oe_call_proposals.default.yml
@@ -175,6 +175,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   oe_departments:
     type: skos_concept_entity_reference_autocomplete
     weight: 12
@@ -212,6 +213,7 @@ content:
       maxlength:
         maxlength_js: 150
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   oe_subject:
     type: skos_concept_entity_reference_autocomplete
     weight: 2
@@ -286,6 +288,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   uid:
     type: entity_reference_autocomplete
     weight: 19

--- a/modules/oe_content_call_tenders/config/install/core.entity_form_display.node.oe_call_tenders.default.yml
+++ b/modules/oe_content_call_tenders/config/install/core.entity_form_display.node.oe_call_tenders.default.yml
@@ -116,6 +116,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   oe_departments:
     type: skos_concept_entity_reference_autocomplete
     weight: 7
@@ -224,6 +225,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   uid:
     type: entity_reference_autocomplete
     weight: 15

--- a/modules/oe_content_consultation/config/install/core.entity_form_display.node.oe_consultation.default.yml
+++ b/modules/oe_content_consultation/config/install/core.entity_form_display.node.oe_consultation.default.yml
@@ -224,6 +224,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   oe_departments:
     type: skos_concept_entity_reference_autocomplete
     weight: 4
@@ -308,6 +309,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   uid:
     type: entity_reference_autocomplete
     weight: 21

--- a/modules/oe_content_event/config/install/core.entity_form_display.node.oe_event.default.yml
+++ b/modules/oe_content_event/config/install/core.entity_form_display.node.oe_event.default.yml
@@ -248,6 +248,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   oe_event_contact:
     weight: 18
     settings:
@@ -307,6 +308,7 @@ content:
       maxlength:
         maxlength_js: 150
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
     type: string_textfield
     region: content
   oe_event_languages:

--- a/modules/oe_content_event/modules/oe_content_event_event_programme/config/install/core.entity_form_display.oe_event_programme.oe_default.default.yml
+++ b/modules/oe_content_event/modules/oe_content_event_event_programme/config/install/core.entity_form_display.oe_event_programme.oe_default.default.yml
@@ -32,6 +32,7 @@ content:
       maxlength:
         maxlength_js: 150
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   oe_description:
     weight: 1
     settings:

--- a/modules/oe_content_event/modules/oe_content_event_person_reference/config/install/core.entity_form_display.oe_event_speaker.oe_default.default.yml
+++ b/modules/oe_content_event/modules/oe_content_event_person_reference/config/install/core.entity_form_display.oe_event_speaker.oe_default.default.yml
@@ -21,6 +21,7 @@ content:
       maxlength:
         maxlength_js: 150
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
     type: string_textfield
     region: content
   oe_person:

--- a/modules/oe_content_news/config/install/core.entity_form_display.node.oe_news.default.yml
+++ b/modules/oe_content_news/config/install/core.entity_form_display.node.oe_news.default.yml
@@ -139,6 +139,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   oe_departments:
     type: skos_concept_entity_reference_autocomplete
     weight: 11
@@ -304,6 +305,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   uid:
     type: entity_reference_autocomplete
     weight: 16

--- a/modules/oe_content_page/config/install/core.entity_form_display.node.oe_page.default.yml
+++ b/modules/oe_content_page/config/install/core.entity_form_display.node.oe_page.default.yml
@@ -70,6 +70,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   oe_author:
     weight: 5
     settings:
@@ -146,6 +147,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   uid:
     type: entity_reference_autocomplete
     weight: 10

--- a/modules/oe_content_person/config/install/core.entity_form_display.node.oe_person.default.yml
+++ b/modules/oe_content_person/config/install/core.entity_form_display.node.oe_person.default.yml
@@ -111,6 +111,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   oe_departments:
     type: skos_concept_entity_reference_autocomplete
     weight: 9

--- a/modules/oe_content_publication/config/install/core.entity_form_display.node.oe_publication.default.yml
+++ b/modules/oe_content_publication/config/install/core.entity_form_display.node.oe_publication.default.yml
@@ -121,6 +121,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   oe_departments:
     type: skos_concept_entity_reference_autocomplete
     weight: 11
@@ -228,6 +229,7 @@ content:
       maxlength:
         maxlength_js: 250
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   oe_subject:
     type: skos_concept_entity_reference_autocomplete
     weight: 5
@@ -302,6 +304,7 @@ content:
       maxlength:
         maxlength_js: 170
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   uid:
     type: entity_reference_autocomplete
     weight: 20


### PR DESCRIPTION
After maxlength release 2.0.0-rc1 the module doesn't use the html attribute of maxlength that enforced the limit on fields.
The module takes care of that by configuration. In order to ensure the same behaviour this configuration has to be enabled for text fields for the module to enforce and truncate extra strings above the limit. 