### PR TITLE
EWPP-0000: Fix persistent url test and magic getter returning false

### DIFF
--- a/modules/oe_content_persistent/tests/modules/oe_content_persistent_test/src/EventSubscriber/PersistentUrlResolverSubscriber.php
+++ b/modules/oe_content_persistent/tests/modules/oe_content_persistent_test/src/EventSubscriber/PersistentUrlResolverSubscriber.php
@@ -26,7 +26,7 @@ class PersistentUrlResolverSubscriber implements EventSubscriberInterface {
     }
 
     if ($entity->label() === 'External') {
-      $event->setUrl(Url::fromUri('https://ec.europa.eu'));
+      $event->setUrl(Url::fromUri('https://commission.europa.eu/index_en'));
     }
 
     if ($entity->label() === 'Early render') {

--- a/modules/oe_content_persistent/tests/src/Functional/PersistentUrlControllerTest.php
+++ b/modules/oe_content_persistent/tests/src/Functional/PersistentUrlControllerTest.php
@@ -106,7 +106,7 @@ class PersistentUrlControllerTest extends BrowserTestBase {
     $node->save();
     $this->drupalGet('/content/' . $node->uuid());
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->addressEquals('https://ec.europa.eu');
+    $this->assertSession()->addressEquals('https://commission.europa.eu/index_en');
 
     \Drupal::entityTypeManager()->getStorage('node')->resetCache();
     $node = \Drupal::service('entity_type.manager')->getStorage('node')->load($node->id());

--- a/modules/oe_content_timeline_field/src/Plugin/Field/FieldWidget/TimelineFieldWidget.php
+++ b/modules/oe_content_timeline_field/src/Plugin/Field/FieldWidget/TimelineFieldWidget.php
@@ -75,7 +75,8 @@ class TimelineFieldWidget extends WidgetBase implements WidgetInterface {
    * {@inheritdoc}
    */
   public function errorElement(array $element, ConstraintViolationInterface $violation, array $form, FormStateInterface $form_state) {
-    if (!empty($violation->arrayPropertyPath) && $sub_element = NestedArray::getValue($element, $violation->arrayPropertyPath)) {
+    $property_path = $violation->arrayPropertyPath;
+    if (!empty($property_path) && $sub_element = NestedArray::getValue($element, $property_path)) {
       return $sub_element;
     }
     return $element;


### PR DESCRIPTION
Fix the test after the `https://ec.europa.eu` is redirecting to `https://commission.europa.eu/`. The test should use the new default url in order to make redirect request that doesn't redirect further.