### PR TITLE
ELA-665: Allow 'oe_featured_media' type to be displayed.

### DIFF
--- a/modules/oe_content_featured_media_field/src/Plugin/Field/FieldType/FeaturedMediaItem.php
+++ b/modules/oe_content_featured_media_field/src/Plugin/Field/FieldType/FeaturedMediaItem.php
@@ -87,4 +87,12 @@ class FeaturedMediaItem extends EntityReferenceItem {
     return $schema;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function isDisplayed() {
+    // OE Feature Media items do not have per-item visibility settings.
+    return TRUE;
+  }
+
 }


### PR DESCRIPTION
Without this, it is not possible to see the field in the "Manage display" of your content type.

/admin/structure/types/manage/<YOUR_CT>/display


In my personal need, I use it with https://github.com/openeuropa/oe_bootstrap_theme/pull/350 this widget that allow me to configure Image style by config / Back office webmastering