### PR TITLE
EWPP-0000: Field group patch update for version 3.6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
                 "https://www.drupal.org/project/drupal/issues/2230909": "https://www.drupal.org/files/issues/2023-12-21/2230909-309.patch"
             },
             "drupal/field_group": {
-                "https://www.drupal.org/project/field_group/issues/2787179": "https://www.drupal.org/files/issues/2023-04-07/2787179-highlight-html5-validation-85.patch"
+                "https://www.drupal.org/project/field_group/issues/2787179": "https://www.drupal.org/files/issues/2024-08-05/2787179-highlight-html5-validation-101.patch"
             },
             "drupal/entity_browser": {
                 "https://www.drupal.org/project/entity_browser/issues/2851580": "https://www.drupal.org/files/issues/2023-12-12/2851580-117.patch"


### PR DESCRIPTION
An ASAP patch for new version of field_group. The old one does not work anymore.