### PR TITLE
EWPP-5467: Fix missing schema for PersonReferenceFormatter.

### DIFF
--- a/modules/oe_content_sub_entity/modules/oe_content_sub_entity_person/config/schema/oe_content_sub_entity_person.schema.yml
+++ b/modules/oe_content_sub_entity/modules/oe_content_sub_entity_person/config/schema/oe_content_sub_entity_person.schema.yml
@@ -11,3 +11,17 @@ oe_content_sub_entity_person.oe_person_type.*:
     description:
       type: text
       label: 'Description'
+
+field.formatter.settings.oe_content_sub_entity_person_reference_formatter:
+  type: mapping
+  label: 'Person reference field formatter settings'
+  mapping:
+    label_only:
+      type: boolean
+      label: 'Display as label'
+    rel:
+      type: string
+      label: 'Add rel "nofollow" to links'
+    target:
+      type: string
+      label: 'Open link in new window'


### PR DESCRIPTION
## EWPP-5467

### Description
Add formatter settings schema for `oe_content_sub_entity_person_reference_formatter`
Fixes issue https://github.com/openeuropa/oe_content/issues/634

### Change log

- Added: formatter settings schema for `oe_content_sub_entity_person_reference_formatter`
- Changed: N/A
- Deprecated: N/A
- Removed: N/A
- Fixed: https://github.com/openeuropa/oe_content/issues/634
- Security: N/A
